### PR TITLE
Publish the docker image also as the latest tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -137,6 +137,8 @@ jobs:
               # set v2 tag for default branch
               type=raw,value=v2,enable={{is_default_branch}}
               type=ref,event=pr
+              # set latest tag for default branch
+              type=raw,value=latest,enable={{is_default_branch}}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
#### PR Classification
New feature to enhance Docker image tagging.

#### PR Summary
This pull request adds a new `latest` tag for the Docker image in addition to the existing `v2` tag for the default branch. 
- `docker-publish.yml`: Added a line to set the `latest` tag for the default branch.
