### PR TITLE
chore(deps): upgrade NuGet packages to latest versions

### DIFF
--- a/AI/AI.Agents.UnitTests/AI.Agents.UnitTests.csproj
+++ b/AI/AI.Agents.UnitTests/AI.Agents.UnitTests.csproj
@@ -16,6 +16,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.Agents.AI" Version="1.17.0" />
 		<PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.17.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.v3" Version="3.2.2" />

--- a/AI/AI.Agents/AI.Agents.csproj
+++ b/AI/AI.Agents/AI.Agents.csproj
@@ -11,8 +11,8 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Agents.AI" Version="1.17.0" />
 		<PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.17.0" />
-		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.8.3" />
-		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
+		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
+		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/AI/AI.Common/AI.Common.csproj
+++ b/AI/AI.Common/AI.Common.csproj
@@ -11,8 +11,8 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Agents.AI" Version="1.17.0" />
 		<PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.17.0" />
-		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.8.3" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
 	</ItemGroup>
 
 </Project>

--- a/AI/AI.Functions.UnitTests/AI.Functions.UnitTests.csproj
+++ b/AI/AI.Functions.UnitTests/AI.Functions.UnitTests.csproj
@@ -16,6 +16,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.Agents.AI" Version="1.17.0" />
 		<PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.17.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.v3" Version="3.2.2" />

--- a/AI/AI.Functions/AI.Functions.csproj
+++ b/AI/AI.Functions/AI.Functions.csproj
@@ -11,7 +11,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Agents.AI" Version="1.17.0" />
 		<PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.17.0" />
-		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.8.3" />
+		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
 		<ProjectReference Include="..\AI.Common\AI.Common.csproj" />
 	</ItemGroup>
 

--- a/Configuration.UnitTests/Configuration.UnitTests.csproj
+++ b/Configuration.UnitTests/Configuration.UnitTests.csproj
@@ -18,8 +18,8 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="AwesomeAssertions" Version="9.5.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/Configuration/Configuration.csproj
+++ b/Configuration/Configuration.csproj
@@ -13,8 +13,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
 	</ItemGroup>
 
 </Project>

--- a/Cryptocurrency.UnitTests/Cryptocurrency.UnitTests.csproj
+++ b/Cryptocurrency.UnitTests/Cryptocurrency.UnitTests.csproj
@@ -24,7 +24,8 @@
 	<ItemGroup>
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="AwesomeAssertions" Version="9.5.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="Polly" Version="8.7.0" />

--- a/Database.UnitTests/Database.UnitTests.csproj
+++ b/Database.UnitTests/Database.UnitTests.csproj
@@ -15,8 +15,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0.2" />

--- a/Database/Database.csproj
+++ b/Database/Database.csproj
@@ -16,13 +16,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="CompareNETObjects" Version="4.84.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="10.0.10" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="10.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/ExternalDataProvider.UnitTests/ExternalDataProvider.UnitTests.csproj
+++ b/ExternalDataProvider.UnitTests/ExternalDataProvider.UnitTests.csproj
@@ -16,8 +16,8 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Polly" Version="8.7.0" />

--- a/ExternalDataProvider/ExternalDataProvider.csproj
+++ b/ExternalDataProvider/ExternalDataProvider.csproj
@@ -11,8 +11,8 @@
 	<ItemGroup>
 	  <PackageReference Include="CoinGecko.Net" Version="6.3.0" />
 	  <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
 	  <PackageReference Include="Polly" Version="8.7.0" />
 	  <PackageReference Include="YahooFinanceApiNext" Version="2.3.11" />
 	</ItemGroup>

--- a/GhostfolioAPI.UnitTests/GhostfolioAPI.UnitTests.csproj
+++ b/GhostfolioAPI.UnitTests/GhostfolioAPI.UnitTests.csproj
@@ -19,8 +19,8 @@
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="AwesomeAssertions" Version="9.5.0" />
 		<PackageReference Include="ILogger.Moq" Version="2.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/GhostfolioAPI/GhostfolioAPI.csproj
+++ b/GhostfolioAPI/GhostfolioAPI.csproj
@@ -14,10 +14,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="FuzzySharp" Version="2.0.2" />
-		<PackageReference Include="Microsoft.Bcl.TimeProvider" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Bcl.TimeProvider" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="Polly" Version="8.7.0" />
 		<PackageReference Include="RestSharp" Version="114.0.0" />

--- a/GhostfolioSidekick.UnitTests/GhostfolioSidekick.UnitTests.csproj
+++ b/GhostfolioSidekick.UnitTests/GhostfolioSidekick.UnitTests.csproj
@@ -16,9 +16,9 @@
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="AwesomeAssertions" Version="9.5.0" />
 		<PackageReference Include="ILogger.Moq" Version="2.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0.2" />

--- a/GhostfolioSidekick/GhostfolioSidekick.csproj
+++ b/GhostfolioSidekick/GhostfolioSidekick.csproj
@@ -9,7 +9,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+		<PackageReference Include="SSH.NET" Version="2026.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/IntegrationTests/IntegrationTests.csproj
+++ b/IntegrationTests/IntegrationTests.csproj
@@ -14,6 +14,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Testcontainers" Version="4.13.0" />
 		<PackageReference Include="Testcontainers.PostgreSql" Version="4.13.0" />

--- a/Model.UnitTests/Model.UnitTests.csproj
+++ b/Model.UnitTests/Model.UnitTests.csproj
@@ -18,7 +18,7 @@
 	<ItemGroup>
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="AwesomeAssertions" Version="9.5.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Polly" Version="8.7.0" />

--- a/Parsers.UnitTests/Parsers.UnitTests.csproj
+++ b/Parsers.UnitTests/Parsers.UnitTests.csproj
@@ -23,8 +23,8 @@
 	<ItemGroup>
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="AwesomeAssertions" Version="9.5.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/Parsers/Parsers.csproj
+++ b/Parsers/Parsers.csproj
@@ -15,9 +15,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="CsvHelper" Version="33.1.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
 		<PackageReference Include="itext" Version="9.7.0" />

--- a/PerformanceCalculations.UnitTests/PerformanceCalculations.UnitTests.csproj
+++ b/PerformanceCalculations.UnitTests/PerformanceCalculations.UnitTests.csproj
@@ -18,9 +18,9 @@
 	<ItemGroup>
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="AwesomeAssertions" Version="9.5.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.v3" Version="3.2.2" />

--- a/PerformanceCalculations/PerformanceCalculations.csproj
+++ b/PerformanceCalculations/PerformanceCalculations.csproj
@@ -14,4 +14,8 @@
 		<ProjectReference Include="..\Model\Model.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
+	</ItemGroup>
+
 </Project>

--- a/PortfolioViewer/PortfolioViewer.ApiService.UnitTests/PortfolioViewer.ApiService.UnitTests.csproj
+++ b/PortfolioViewer/PortfolioViewer.ApiService.UnitTests/PortfolioViewer.ApiService.UnitTests.csproj
@@ -15,6 +15,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.v3" Version="3.2.2" />

--- a/PortfolioViewer/PortfolioViewer.ApiService/PortfolioViewer.ApiService.csproj
+++ b/PortfolioViewer/PortfolioViewer.ApiService/PortfolioViewer.ApiService.csproj
@@ -19,8 +19,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
-		<PackageReference Include="Scalar.AspNetCore" Version="2.16.18" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
+		<PackageReference Include="Scalar.AspNetCore" Version="2.16.19" />
 		<PackageReference Include="Grpc.AspNetCore" Version="2.83.0" />
 		<PackageReference Include="Grpc.AspNetCore.Web" Version="2.83.0" />
 	</ItemGroup>

--- a/PortfolioViewer/PortfolioViewer.Common/PortfolioViewer.Common.csproj
+++ b/PortfolioViewer/PortfolioViewer.Common/PortfolioViewer.Common.csproj
@@ -12,4 +12,9 @@
 	  <ProjectReference Include="..\..\Database\Database.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+	</ItemGroup>
+
 </Project>

--- a/PortfolioViewer/PortfolioViewer.ServiceDefaults/PortfolioViewer.ServiceDefaults.csproj
+++ b/PortfolioViewer/PortfolioViewer.ServiceDefaults/PortfolioViewer.ServiceDefaults.csproj
@@ -21,8 +21,8 @@
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
-		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
+		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
+		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.9.0" />
 		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />

--- a/PortfolioViewer/PortfolioViewer.Tests/PortfolioViewer.Tests.csproj
+++ b/PortfolioViewer/PortfolioViewer.Tests/PortfolioViewer.Tests.csproj
@@ -16,6 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/PortfolioViewer/PortfolioViewer.WASM.AI.UnitTests/PortfolioViewer.WASM.AI.UnitTests.csproj
+++ b/PortfolioViewer/PortfolioViewer.WASM.AI.UnitTests/PortfolioViewer.WASM.AI.UnitTests.csproj
@@ -15,6 +15,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Agents.AI" Version="1.17.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="xunit.v3" Version="3.2.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -22,9 +23,9 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.8.3" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
 	</ItemGroup>
 	<ItemGroup>
 		<Using Include="Xunit" />

--- a/PortfolioViewer/PortfolioViewer.WASM.AI/PortfolioViewer.WASM.AI.csproj
+++ b/PortfolioViewer/PortfolioViewer.WASM.AI/PortfolioViewer.WASM.AI.csproj
@@ -11,9 +11,9 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Agents.AI" Version="1.17.0" />
 		<PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.17.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.8.3" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/PortfolioViewer/PortfolioViewer.WASM.Data.UnitTests/PortfolioViewer.WASM.Data.UnitTests.csproj
+++ b/PortfolioViewer/PortfolioViewer.WASM.Data.UnitTests/PortfolioViewer.WASM.Data.UnitTests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -21,7 +22,7 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Database\Database.csproj" />

--- a/PortfolioViewer/PortfolioViewer.WASM.Data/PortfolioViewer.WASM.Data.csproj
+++ b/PortfolioViewer/PortfolioViewer.WASM.Data/PortfolioViewer.WASM.Data.csproj
@@ -16,4 +16,10 @@
 	  <Folder Include="Benchmarks\" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
+	  <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+	</ItemGroup>
+
 </Project>

--- a/PortfolioViewer/PortfolioViewer.WASM.UITests/PortfolioViewer.WASM.UITests.csproj
+++ b/PortfolioViewer/PortfolioViewer.WASM.UITests/PortfolioViewer.WASM.UITests.csproj
@@ -12,6 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Microsoft.Playwright" Version="1.62.0" />
     <PackageReference Include="Moq" Version="4.20.72" />

--- a/PortfolioViewer/PortfolioViewer.WASM.UnitTests/PortfolioViewer.WASM.UnitTests.csproj
+++ b/PortfolioViewer/PortfolioViewer.WASM.UnitTests/PortfolioViewer.WASM.UnitTests.csproj
@@ -16,6 +16,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0.2" />

--- a/PortfolioViewer/PortfolioViewer.WASM/PortfolioViewer.WASM.csproj
+++ b/PortfolioViewer/PortfolioViewer.WASM/PortfolioViewer.WASM.csproj
@@ -35,10 +35,10 @@
 	<ItemGroup>
 		<PackageReference Include="Bit.Besql" Version="10.5.0" />
 		<PackageReference Include="Markdig" Version="1.3.2" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.11" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.9.0" />
 		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="7.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -48,7 +48,7 @@
 		<PackageReference Include="Grpc.Net.Client" Version="2.83.0" />
 		<PackageReference Include="Google.Protobuf" Version="3.35.1" />
 		<PackageReference Include="Grpc.Tools" Version="2.83.0" PrivateAssets="All" />
-		<PackageReference Include="Microsoft.NET.Sdk.WebAssembly.Pack" Version="10.0.10" />
+		<PackageReference Include="Microsoft.NET.Sdk.WebAssembly.Pack" Version="10.0.11" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tools/AnonymisePDF.UnitTests/AnonymisePDF.UnitTests.csproj
+++ b/Tools/AnonymisePDF.UnitTests/AnonymisePDF.UnitTests.csproj
@@ -20,7 +20,8 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="AwesomeAssertions" Version="9.5.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="Polly" Version="8.7.0" />
 		<PackageReference Include="xunit.v3" Version="3.2.2" />

--- a/Tools/AnonymisePDF/AnonymisePDF.csproj
+++ b/Tools/AnonymisePDF/AnonymisePDF.csproj
@@ -18,8 +18,8 @@
 		<PackageReference Include="BouncyCastle.Cryptography" Version="2.7.0" />
 		<PackageReference Include="itext.bouncy-castle-adapter" Version="9.7.0" />
 		<PackageReference Include="itext.pdfsweep" Version="5.0.7" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 	</ItemGroup>
 

--- a/Tools/ScraperUtilities/ScraperUtilities.csproj
+++ b/Tools/ScraperUtilities/ScraperUtilities.csproj
@@ -20,8 +20,8 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
 		<PackageReference Include="Microsoft.Playwright" Version="1.62.0" />
 	</ItemGroup>
 

--- a/Utilities.UnitTests/Utilities.UnitTests.csproj
+++ b/Utilities.UnitTests/Utilities.UnitTests.csproj
@@ -15,6 +15,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="xunit.v3" Version="3.2.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
- SSH.NET 2025.1.0 -> 2026.0.0 (security vulnerability fix)
- EF Core 10.0.10 -> 10.0.11
- Microsoft.Extensions.* 10.0.10 -> 10.0.11
- Microsoft.AspNetCore.Components.WebAssembly 10.0.10 -> 10.0.11
- Microsoft.Extensions.Http.Resilience 10.8.0 -> 10.9.0
- Microsoft.Extensions.ServiceDiscovery 10.8.0 -> 10.9.0
- Microsoft.Extensions.AI.Abstractions 10.8.3 -> 10.9.0
- SQLitePCLRaw 2.1.11 -> 2.1.12
- Scalar.AspNetCore 2.16.18 -> 2.16.19
- Microsoft.AspNetCore.OpenApi 10.0.10 -> 10.0.11
- Microsoft.EntityFrameworkCore.InMemory 10.0.10 -> 10.0.11
- Microsoft.Bcl.TimeProvider 10.0.10 -> 10.0.11
- Microsoft.Extensions.Caching.Memory 10.0.10 -> 10.0.11

Build: 0 errors, 0 warnings
Tests: all passed
Vulnerabilities: none