### PR TITLE
Adopt NuGet Central Package Management

### DIFF
--- a/AI/AI.Agents.UnitTests/AI.Agents.UnitTests.csproj
+++ b/AI/AI.Agents.UnitTests/AI.Agents.UnitTests.csproj
@@ -9,18 +9,18 @@
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="coverlet.collector">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Agents.AI" Version="1.19.0" />
-		<PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.19.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="Microsoft.Agents.AI" />
+		<PackageReference Include="Microsoft.Agents.AI.Workflows" />
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/AI/AI.Agents/AI.Agents.csproj
+++ b/AI/AI.Agents/AI.Agents.csproj
@@ -9,10 +9,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Agents.AI" Version="1.19.0" />
-		<PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.19.0" />
-		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
-		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
+		<PackageReference Include="Microsoft.Agents.AI" />
+		<PackageReference Include="Microsoft.Agents.AI.Workflows" />
+		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Http.Resilience" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/AI/AI.Common/AI.Common.csproj
+++ b/AI/AI.Common/AI.Common.csproj
@@ -9,10 +9,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Agents.AI" Version="1.19.0" />
-		<PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.19.0" />
-		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Agents.AI" />
+		<PackageReference Include="Microsoft.Agents.AI.Workflows" />
+		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
 	</ItemGroup>
 
 </Project>

--- a/AI/AI.Functions.UnitTests/AI.Functions.UnitTests.csproj
+++ b/AI/AI.Functions.UnitTests/AI.Functions.UnitTests.csproj
@@ -9,18 +9,18 @@
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="coverlet.collector">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Agents.AI" Version="1.19.0" />
-		<PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.19.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="Microsoft.Agents.AI" />
+		<PackageReference Include="Microsoft.Agents.AI.Workflows" />
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/AI/AI.Functions/AI.Functions.csproj
+++ b/AI/AI.Functions/AI.Functions.csproj
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Agents.AI" Version="1.19.0" />
-		<PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.19.0" />
-		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
+		<PackageReference Include="Microsoft.Agents.AI" />
+		<PackageReference Include="Microsoft.Agents.AI.Workflows" />
+		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
 		<ProjectReference Include="..\AI.Common\AI.Common.csproj" />
 	</ItemGroup>
 

--- a/Configuration.UnitTests/Configuration.UnitTests.csproj
+++ b/Configuration.UnitTests/Configuration.UnitTests.csproj
@@ -17,19 +17,19 @@
 		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="Polly" Version="8.7.0" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="Polly" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="coverlet.collector">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Configuration/Configuration.csproj
+++ b/Configuration/Configuration.csproj
@@ -13,8 +13,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
 	</ItemGroup>
 
 </Project>

--- a/Cryptocurrency.UnitTests/Cryptocurrency.UnitTests.csproj
+++ b/Cryptocurrency.UnitTests/Cryptocurrency.UnitTests.csproj
@@ -22,19 +22,19 @@
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AutoFixture" Version="4.18.1" />
-		<PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="Polly" Version="8.7.0" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="AutoFixture" />
+		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="Polly" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="coverlet.collector">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Cryptocurrency/Cryptocurrency.csproj
+++ b/Cryptocurrency/Cryptocurrency.csproj
@@ -21,7 +21,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="Newtonsoft.Json" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Database.UnitTests/Database.UnitTests.csproj
+++ b/Database.UnitTests/Database.UnitTests.csproj
@@ -10,19 +10,19 @@
 		<RootNamespace>GhostfolioSidekick.Tools.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="coverlet.collector">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0.2" />
-		<PackageReference Include="Polly" Version="8.7.0" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="Moq.EntityFrameworkCore" />
+		<PackageReference Include="Polly" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Database/Database.csproj
+++ b/Database/Database.csproj
@@ -15,14 +15,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CompareNETObjects" Version="4.84.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="10.0.11" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
+		<PackageReference Include="CompareNETObjects" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,76 @@
+<Project>
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageVersion Include="AngleSharp" Version="1.7.2" />
+		<PackageVersion Include="Aspire.Hosting.AppHost" Version="13.5.3" />
+		<PackageVersion Include="Aspire.Hosting.Blazor" Version="13.4.6-preview.1.26319.6" />
+		<PackageVersion Include="Aspire.Hosting.Testing" Version="13.5.3" />
+		<PackageVersion Include="AutoFixture" Version="4.18.1" />
+		<PackageVersion Include="AwesomeAssertions" Version="9.6.0" />
+		<PackageVersion Include="Bit.Besql" Version="10.5.0" />
+		<PackageVersion Include="bunit" Version="2.9.0" />
+		<PackageVersion Include="CoinGecko.Net" Version="6.4.0" />
+		<PackageVersion Include="CompareNETObjects" Version="4.84.0" />
+		<PackageVersion Include="coverlet.collector" Version="10.0.1" />
+		<PackageVersion Include="CsvHelper" Version="33.1.0" />
+		<PackageVersion Include="Fastenshtein" Version="1.0.12" />
+		<PackageVersion Include="FuzzySharp" Version="2.0.2" />
+		<PackageVersion Include="Google.Protobuf" Version="3.36.0" />
+		<PackageVersion Include="Grpc.AspNetCore" Version="2.83.0" />
+		<PackageVersion Include="Grpc.AspNetCore.Web" Version="2.83.0" />
+		<PackageVersion Include="Grpc.Net.Client" Version="2.83.0" />
+		<PackageVersion Include="Grpc.Net.Client.Web" Version="2.83.0" />
+		<PackageVersion Include="Grpc.Tools" Version="2.83.0" />
+		<PackageVersion Include="HtmlAgilityPack" Version="1.13.0" />
+		<PackageVersion Include="ILogger.Moq" Version="2.0.0" />
+		<PackageVersion Include="Markdig" Version="1.3.2" />
+		<PackageVersion Include="Microsoft.Agents.AI" Version="1.19.0" />
+		<PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.19.0" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.EntityFrameworkCore.Proxies" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
+		<PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
+		<PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.9.0" />
+		<PackageVersion Include="Microsoft.NET.Sdk.WebAssembly.Pack" Version="10.0.11" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+		<PackageVersion Include="Microsoft.Playwright" Version="1.62.0" />
+		<PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="7.0.1" />
+		<PackageVersion Include="Moq" Version="4.20.72" />
+		<PackageVersion Include="Moq.EntityFrameworkCore" Version="10.0.0.2" />
+		<PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
+		<PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+		<PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
+		<PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
+		<PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.18.0" />
+		<PackageVersion Include="Plotly.Blazor" Version="7.2.0" />
+		<PackageVersion Include="Polly" Version="8.7.0" />
+		<PackageVersion Include="RestSharp" Version="114.0.0" />
+		<PackageVersion Include="Scalar.AspNetCore" Version="2.17.1" />
+		<PackageVersion Include="SSH.NET" Version="2026.0.0" />
+		<PackageVersion Include="Testcontainers" Version="4.14.0" />
+		<PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />
+		<PackageVersion Include="Testcontainers.Redis" Version="4.14.0" />
+		<PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
+		<PackageVersion Include="xunit.v3" Version="4.0.0" />
+		<PackageVersion Include="YahooFinanceApiNext" Version="2.3.11" />
+	</ItemGroup>
+</Project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN apt-get update && \
 COPY ["PortfolioViewer/PortfolioViewer.ApiService/PortfolioViewer.ApiService.csproj", "PortfolioViewer.ApiService/"]
 COPY ["PortfolioViewer/PortfolioViewer.WASM/PortfolioViewer.WASM.csproj", "PortfolioViewer.WASM/"]
 COPY ["GhostfolioSidekick/GhostfolioSidekick.csproj", "GhostfolioSidekick/"]
+# Central package management: versions live here, so it must exist before restore
+COPY ["Directory.Packages.props", "./"]
 
 RUN dotnet restore -a "$TARGETARCH" "PortfolioViewer.ApiService/PortfolioViewer.ApiService.csproj" && \
     dotnet restore -a "$TARGETARCH" "PortfolioViewer.WASM/PortfolioViewer.WASM.csproj" && \

--- a/ExternalDataProvider.UnitTests/ExternalDataProvider.UnitTests.csproj
+++ b/ExternalDataProvider.UnitTests/ExternalDataProvider.UnitTests.csproj
@@ -10,19 +10,19 @@
 		<IsTestProject>true</IsTestProject>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="coverlet.collector">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Polly" Version="8.7.0" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="Polly" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/ExternalDataProvider/ExternalDataProvider.csproj
+++ b/ExternalDataProvider/ExternalDataProvider.csproj
@@ -9,12 +9,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="CoinGecko.Net" Version="6.4.0" />
-	  <PackageReference Include="HtmlAgilityPack" Version="1.13.0" />
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-	  <PackageReference Include="Polly" Version="8.7.0" />
-	  <PackageReference Include="YahooFinanceApiNext" Version="2.3.11" />
+	  <PackageReference Include="CoinGecko.Net" />
+	  <PackageReference Include="HtmlAgilityPack" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+	  <PackageReference Include="Polly" />
+	  <PackageReference Include="YahooFinanceApiNext" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/GhostfolioAPI.UnitTests/GhostfolioAPI.UnitTests.csproj
+++ b/GhostfolioAPI.UnitTests/GhostfolioAPI.UnitTests.csproj
@@ -16,22 +16,22 @@
 		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="AutoFixture" Version="4.18.1" />
-		<PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-		<PackageReference Include="ILogger.Moq" Version="2.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="Polly" Version="8.7.0" />
-		<PackageReference Include="RestSharp" Version="114.0.0" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="AutoFixture" />
+		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="ILogger.Moq" />
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="Polly" />
+		<PackageReference Include="RestSharp" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="coverlet.collector">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/GhostfolioAPI/GhostfolioAPI.csproj
+++ b/GhostfolioAPI/GhostfolioAPI.csproj
@@ -13,14 +13,14 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FuzzySharp" Version="2.0.2" />
-		<PackageReference Include="Microsoft.Bcl.TimeProvider" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="Polly" Version="8.7.0" />
-		<PackageReference Include="RestSharp" Version="114.0.0" />
+		<PackageReference Include="FuzzySharp" />
+		<PackageReference Include="Microsoft.Bcl.TimeProvider" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="Polly" />
+		<PackageReference Include="RestSharp" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/GhostfolioSidekick.UnitTests/GhostfolioSidekick.UnitTests.csproj
+++ b/GhostfolioSidekick.UnitTests/GhostfolioSidekick.UnitTests.csproj
@@ -13,23 +13,23 @@
 		<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AutoFixture" Version="4.18.1" />
-		<PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-		<PackageReference Include="ILogger.Moq" Version="2.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0.2" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="Polly" Version="8.7.0" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="AutoFixture" />
+		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="ILogger.Moq" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="Moq.EntityFrameworkCore" />
+		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="Polly" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="coverlet.collector">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/GhostfolioSidekick/GhostfolioSidekick.csproj
+++ b/GhostfolioSidekick/GhostfolioSidekick.csproj
@@ -9,8 +9,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
-		<PackageReference Include="SSH.NET" Version="2026.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" />
+		<PackageReference Include="SSH.NET" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/IntegrationTests/IntegrationTests.csproj
+++ b/IntegrationTests/IntegrationTests.csproj
@@ -9,18 +9,18 @@
 		<RootNamespace>GhostfolioSidekick.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="coverlet.collector">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="Testcontainers" Version="4.14.0" />
-		<PackageReference Include="Testcontainers.PostgreSql" Version="4.14.0" />
-		<PackageReference Include="Testcontainers.Redis" Version="4.14.0" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Testcontainers" />
+		<PackageReference Include="Testcontainers.PostgreSql" />
+		<PackageReference Include="Testcontainers.Redis" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Model.UnitTests/Model.UnitTests.csproj
+++ b/Model.UnitTests/Model.UnitTests.csproj
@@ -16,19 +16,19 @@
 		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="AutoFixture" Version="4.18.1" />
-		<PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Polly" Version="8.7.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="AutoFixture" />
+		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="Polly" />
+		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="coverlet.collector">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Parsers.UnitTests/Parsers.UnitTests.csproj
+++ b/Parsers.UnitTests/Parsers.UnitTests.csproj
@@ -21,20 +21,20 @@
 		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="AutoFixture" Version="4.18.1" />
-		<PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="Polly" Version="8.7.0" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="AutoFixture" />
+		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="Polly" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="coverlet.collector">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Parsers/Parsers.csproj
+++ b/Parsers/Parsers.csproj
@@ -14,11 +14,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CsvHelper" Version="33.1.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="CsvHelper" />
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+		<PackageReference Include="Newtonsoft.Json" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/PerformanceCalculations.UnitTests/PerformanceCalculations.UnitTests.csproj
+++ b/PerformanceCalculations.UnitTests/PerformanceCalculations.UnitTests.csproj
@@ -16,19 +16,19 @@
 		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="AutoFixture" Version="4.18.1" />
-		<PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="AutoFixture" />
+		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="coverlet.collector">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/PerformanceCalculations/PerformanceCalculations.csproj
+++ b/PerformanceCalculations/PerformanceCalculations.csproj
@@ -15,7 +15,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
 	</ItemGroup>
 
 </Project>

--- a/PortfolioViewer/PortfolioViewer.ApiService.UnitTests/PortfolioViewer.ApiService.UnitTests.csproj
+++ b/PortfolioViewer/PortfolioViewer.ApiService.UnitTests/PortfolioViewer.ApiService.UnitTests.csproj
@@ -9,17 +9,17 @@
 		<RootNamespace>GhostfolioSidekick.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="coverlet.collector">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/PortfolioViewer/PortfolioViewer.ApiService/PortfolioViewer.ApiService.csproj
+++ b/PortfolioViewer/PortfolioViewer.ApiService/PortfolioViewer.ApiService.csproj
@@ -18,11 +18,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="HtmlAgilityPack" Version="1.13.0" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
-		<PackageReference Include="Scalar.AspNetCore" Version="2.17.1" />
-		<PackageReference Include="Grpc.AspNetCore" Version="2.83.0" />
-		<PackageReference Include="Grpc.AspNetCore.Web" Version="2.83.0" />
+		<PackageReference Include="HtmlAgilityPack" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+		<PackageReference Include="Scalar.AspNetCore" />
+		<PackageReference Include="Grpc.AspNetCore" />
+		<PackageReference Include="Grpc.AspNetCore.Web" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/PortfolioViewer/PortfolioViewer.AppHost/PortfolioViewer.AppHost.csproj
+++ b/PortfolioViewer/PortfolioViewer.AppHost/PortfolioViewer.AppHost.csproj
@@ -28,8 +28,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Aspire.Hosting.AppHost" Version="13.5.3" />
-		<PackageReference Include="Aspire.Hosting.Blazor" Version="13.4.6-preview.1.26319.6" />
+		<PackageReference Include="Aspire.Hosting.AppHost" />
+		<PackageReference Include="Aspire.Hosting.Blazor" />
 	</ItemGroup>
 
 </Project>

--- a/PortfolioViewer/PortfolioViewer.Common/PortfolioViewer.Common.csproj
+++ b/PortfolioViewer/PortfolioViewer.Common/PortfolioViewer.Common.csproj
@@ -13,8 +13,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+	  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
 	</ItemGroup>
 
 </Project>

--- a/PortfolioViewer/PortfolioViewer.ServiceDefaults/PortfolioViewer.ServiceDefaults.csproj
+++ b/PortfolioViewer/PortfolioViewer.ServiceDefaults/PortfolioViewer.ServiceDefaults.csproj
@@ -21,13 +21,13 @@
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
-		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.9.0" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
-		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.18.0" />
+		<PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
 	</ItemGroup>
 
 </Project>

--- a/PortfolioViewer/PortfolioViewer.Tests/PortfolioViewer.Tests.csproj
+++ b/PortfolioViewer/PortfolioViewer.Tests/PortfolioViewer.Tests.csproj
@@ -10,16 +10,16 @@
 	  <RootNamespace>GhostfolioSidekick.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" Version="13.5.3" />
-    <PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="Aspire.Hosting.Testing" />
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-    <PackageReference Include="xunit.v3" Version="4.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/PortfolioViewer/PortfolioViewer.WASM.AI.UnitTests/PortfolioViewer.WASM.AI.UnitTests.csproj
+++ b/PortfolioViewer/PortfolioViewer.WASM.AI.UnitTests/PortfolioViewer.WASM.AI.UnitTests.csproj
@@ -9,23 +9,23 @@
 		<RootNamespace>GhostfolioSidekick.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="coverlet.collector">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Agents.AI" Version="1.19.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="Microsoft.Agents.AI" />
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
 	</ItemGroup>
 	<ItemGroup>
 		<Using Include="Xunit" />

--- a/PortfolioViewer/PortfolioViewer.WASM.AI/PortfolioViewer.WASM.AI.csproj
+++ b/PortfolioViewer/PortfolioViewer.WASM.AI/PortfolioViewer.WASM.AI.csproj
@@ -9,11 +9,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Agents.AI" Version="1.19.0" />
-		<PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.19.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Agents.AI" />
+		<PackageReference Include="Microsoft.Agents.AI.Workflows" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+		<PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/PortfolioViewer/PortfolioViewer.WASM.Data.UnitTests/PortfolioViewer.WASM.Data.UnitTests.csproj
+++ b/PortfolioViewer/PortfolioViewer.WASM.Data.UnitTests/PortfolioViewer.WASM.Data.UnitTests.csproj
@@ -8,21 +8,21 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-    <PackageReference Include="xunit.v3" Version="4.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Moq.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Database\Database.csproj" />

--- a/PortfolioViewer/PortfolioViewer.WASM.Data/PortfolioViewer.WASM.Data.csproj
+++ b/PortfolioViewer/PortfolioViewer.WASM.Data/PortfolioViewer.WASM.Data.csproj
@@ -17,9 +17,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
-	  <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+	  <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+	  <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
 	</ItemGroup>
 
 </Project>

--- a/PortfolioViewer/PortfolioViewer.WASM.UITests/PortfolioViewer.WASM.UITests.csproj
+++ b/PortfolioViewer/PortfolioViewer.WASM.UITests/PortfolioViewer.WASM.UITests.csproj
@@ -7,17 +7,17 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.62.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit.v3" Version="4.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Playwright" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/PortfolioViewer/PortfolioViewer.WASM.UnitTests/PortfolioViewer.WASM.UnitTests.csproj
+++ b/PortfolioViewer/PortfolioViewer.WASM.UnitTests/PortfolioViewer.WASM.UnitTests.csproj
@@ -9,19 +9,19 @@
 		<RootNamespace>GhostfolioSidekick.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AngleSharp" Version="1.7.2" />
-		<PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-		<PackageReference Include="bunit" Version="2.9.0" />
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="AngleSharp" />
+		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="bunit" />
+		<PackageReference Include="coverlet.collector">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0.2" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="Moq.EntityFrameworkCore" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/PortfolioViewer/PortfolioViewer.WASM/PortfolioViewer.WASM.csproj
+++ b/PortfolioViewer/PortfolioViewer.WASM/PortfolioViewer.WASM.csproj
@@ -33,22 +33,22 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Bit.Besql" Version="10.5.0" />
-		<PackageReference Include="Markdig" Version="1.3.2" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.11" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.9.0" />
-		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="7.0.1">
+		<PackageReference Include="Bit.Besql" />
+		<PackageReference Include="Markdig" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" />
+		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
+		<PackageReference Include="Microsoft.TypeScript.MSBuild">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Plotly.Blazor" Version="7.2.0" />
-		<PackageReference Include="Grpc.Net.Client.Web" Version="2.83.0" />
-		<PackageReference Include="Grpc.Net.Client" Version="2.83.0" />
-		<PackageReference Include="Google.Protobuf" Version="3.36.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.83.0" PrivateAssets="All" />
-		<PackageReference Include="Microsoft.NET.Sdk.WebAssembly.Pack" Version="10.0.11" />
+		<PackageReference Include="Plotly.Blazor" />
+		<PackageReference Include="Grpc.Net.Client.Web" />
+		<PackageReference Include="Grpc.Net.Client" />
+		<PackageReference Include="Google.Protobuf" />
+		<PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.NET.Sdk.WebAssembly.Pack" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tools/ScraperUtilities/ScraperUtilities.csproj
+++ b/Tools/ScraperUtilities/ScraperUtilities.csproj
@@ -20,9 +20,9 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
-		<PackageReference Include="Microsoft.Playwright" Version="1.62.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+		<PackageReference Include="Microsoft.Playwright" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tools/TestUtilities.UnitTests/TestUtilities.UnitTests.csproj
+++ b/Tools/TestUtilities.UnitTests/TestUtilities.UnitTests.csproj
@@ -16,13 +16,13 @@
 		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="coverlet.collector">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Utilities.UnitTests/Utilities.UnitTests.csproj
+++ b/Utilities.UnitTests/Utilities.UnitTests.csproj
@@ -10,15 +10,15 @@
 		<RootNamespace>GhostfolioSidekick.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="AwesomeAssertions" Version="9.6.0" />
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="AwesomeAssertions" />
+		<PackageReference Include="coverlet.collector">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/Utilities/Utilities.csproj
+++ b/Utilities/Utilities.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Fastenshtein" Version="1.0.12" />
+	  <PackageReference Include="Fastenshtein" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Move all 68 package versions from the 40 project files into a single Directory.Packages.props (ManagePackageVersionsCentrally=true) and strip the Version attribute from every PackageReference. Versions are unchanged, so restore/build/test behavior is identical; verified with a full build (0 errors) and the complete test suite (1836 passed).