### PR TITLE
feat(scraper): add Scalable Capital CLI API option

### DIFF
--- a/.github/skills/scalable-cli-sync/SKILL.md
+++ b/.github/skills/scalable-cli-sync/SKILL.md
@@ -22,6 +22,7 @@ Sync upstream `ScalableCapital/scalable-cli` (Rust) into our C# port. Our port e
 |---|---|---|
 | `auth.rs`, `token.rs`, `session.rs` | `CliTokenProvider.cs`, `CliTokenStore.cs` | Device-code OAuth flow, token refresh rotation, claim extraction, persisted session (`cli-tokens.json`) |
 | `dpop*.rs` (mod + software impl) | `DpopKey.cs` | ES256 key gen/load, DPoP proof JWT construction, JWK embedding |
+| `auth.rs` (`handle_post_login_mfa`) + 2FA ops in `graphql.rs` | `TrustedDevice2Fa.cs` | Post-login trusted-device 2FA: Is2faOnLoginEnabled gate (enabled/hasApprovedSession), Start2faOnLogin (deviceName/deviceType "CLI"), Validate2faOnLogin poll every 2s, 120s deadline. Invoked via `CliTokenProvider.OnDeviceLogin` after device-code login only |
 | `graphql.rs`, broker/overnight query execution | `CliGraphqlClient.cs` | GraphQL POST transport, DPoP nonce retry, 401 force-refresh-retry-once (`execute_with_refresh_retry` equivalent) |
 | `broker_queries.rs`, `overnight_queries.rs` | `CliScraper.cs` (verbatim query strings) | The 5 GraphQL queries: ResolveBrokerIds, BrokerTransactions, BrokerTransactionDetails, DiscoverOvernightAccounts, OvernightTransactions; cursor paging pageSize 100 |
 | broker/overnight row mapping + shared/channel types | `CliScraper.cs` (mapping code) | Transaction → model mapping. **Must stay identical to `Mcp/McpScraper.cs`** for fee/tax/cash handling — port any upstream mapping change into both scrapers |
@@ -42,7 +43,7 @@ Sync upstream `ScalableCapital/scalable-cli` (Rust) into our C# port. Our port e
 
 1. **GraphQL queries** — must stay verbatim with upstream (field names, args, pagination shape). Any query text change is a hard requirement to port.
 2. **Endpoints & constants** — issuer `https://secure.scalable.capital` (`/oauth/device/code`, `/oauth/token`), GraphQL `https://de.scalable.capital/api/cli/graphql`, audience `https://de.scalable.capital/api-gateway`, client_id, scope. Upstream constant changes break login silently — check first.
-3. **Auth flow** — device-code polling states (`authorization_pending`, `slow_down`, `access_denied`, `expired_token`), refresh-token rotation (new refresh token must be persisted), claim extraction (`person_id`, `session_id`).
+3. **Auth flow** — device-code polling states (`authorization_pending`, `slow_down`, `access_denied`, `expired_token`), refresh-token rotation (new refresh token must be persisted), claim extraction (`person_id`, `session_id`), post-login trusted-device 2FA state machine (enabled/hasApprovedSession gate, SUCCESS/PENDING/DENY/TIMEOUT_RETRY statuses — error strings are user-visible, keep identical).
 4. **Retry semantics** — Rust wraps every GraphQL call in `execute_with_refresh_retry`: 401 → force session invalidation → re-login/refresh → retry once. Our equivalent is the attempt loop in `CliGraphqlClient.QueryAsync` (DPoP-nonce challenge first, then plain 401). Keep both layers.
 5. **Row mapping** — new transaction types, fee/tax/cash fields, overnight interest handling (`status` SETTLED/FILLED, cashTransactionType INTEREST/INTEREST_PAYMENT).
 
@@ -64,6 +65,8 @@ Sync upstream `ScalableCapital/scalable-cli` (Rust) into our C# port. Our port e
 - **DPoP proof header embeds the full JWK** (`kty`, `crv`, `x`, `y`) — matches upstream software-key behavior, required because we have no server-side key registration.
 - **Key/token files under `%LOCALAPPDATA%\GhostfolioSidekick\`**: `cli-auth-signing-key.json` (minimal JWK kty/crv/d), `cli-tokens.json`. Broad-catch self-heal on load is deliberate.
 - **No Windows binary concern** — we are the implementation; upstream platform-specific code (e.g. browser-open, OS keyring) maps to our console + file-based equivalents.
+- **JWT signature verification NOT ported** (`verify_access_token_strict`: OIDC discovery + JWKS RS256). User decision: TLS to `secure.scalable.capital` is deemed sufficient; the JWKS pipeline adds 2 network calls and a new failure mode per auth event for an unattended container. Revisit if token-endpoint trust assumptions change.
+- **Server-side token revocation on MFA failure NOT ported.** Rust revokes tokens via the API when trusted-device 2FA fails; we clear the local store + force re-auth instead (`CliTokenProvider` hook catch). Effect is equivalent (next run = fresh device login) without an extra endpoint.
 
 ## Parity Reference
 

--- a/.github/skills/scalable-cli-sync/SKILL.md
+++ b/.github/skills/scalable-cli-sync/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: scalable-cli-sync
+description: >
+  Incorporate changes from the official Scalable Capital CLI (Rust,
+  https://github.com/ScalableCapital/scalable-cli) into our C# port at
+  Tools/ScraperUtilities/CliApi/. Use when user asks to "sync scalable-cli",
+  "update the CLI API scraper from upstream", "port changes from the official
+  Scalable Capital CLI", or reports a bug that exists in both.
+---
+
+Sync upstream `ScalableCapital/scalable-cli` (Rust) into our C# port. Our port exists because the MCP server path misses overnight transaction details and no Windows binary of the Rust CLI is published — we maintain the port, so upstream changes must be adopted manually.
+
+## Scope
+
+- Upstream: https://github.com/ScalableCapital/scalable-cli (Rust, `src/*.rs`)
+- Our port: `Tools/ScraperUtilities/CliApi/` (C#, .NET 10)
+- Wiring: `Tools/ScraperUtilities/ScraperService.cs` — menu option "3. Scalable Capital (CLI API)", branch order CLI → MCP → browser
+
+## File Map (Rust → C#)
+
+| Upstream module | Our file | What lives there |
+|---|---|---|
+| `auth.rs`, `token.rs`, `session.rs` | `CliTokenProvider.cs`, `CliTokenStore.cs` | Device-code OAuth flow, token refresh rotation, claim extraction, persisted session (`cli-tokens.json`) |
+| `dpop*.rs` (mod + software impl) | `DpopKey.cs` | ES256 key gen/load, DPoP proof JWT construction, JWK embedding |
+| `graphql.rs`, broker/overnight query execution | `CliGraphqlClient.cs` | GraphQL POST transport, DPoP nonce retry, 401 force-refresh-retry-once (`execute_with_refresh_retry` equivalent) |
+| `broker_queries.rs`, `overnight_queries.rs` | `CliScraper.cs` (verbatim query strings) | The 5 GraphQL queries: ResolveBrokerIds, BrokerTransactions, BrokerTransactionDetails, DiscoverOvernightAccounts, OvernightTransactions; cursor paging pageSize 100 |
+| broker/overnight row mapping + shared/channel types | `CliScraper.cs` (mapping code) | Transaction → model mapping. **Must stay identical to `Mcp/McpScraper.cs`** for fee/tax/cash handling — port any upstream mapping change into both scrapers |
+
+## Runbook
+
+### Phase 1: Fetch upstream source
+
+1. List upstream files (do not clone the whole repo):
+   ```
+   gh api repos/ScalableCapital/scalable-cli/git/trees/main?recursive=1 --jq '.tree[].path'
+   ```
+2. Fetch only the modules relevant to the change via raw URLs:
+   `https://raw.githubusercontent.com/ScalableCapital/scalable-cli/main/src/<file>.rs`
+3. Save fetched files into the session workspace (e.g. `files/scalable-cli-upstream/`) for diffing — never commit them to this repo.
+
+### Phase 2: Diff per area, in priority order
+
+1. **GraphQL queries** — must stay verbatim with upstream (field names, args, pagination shape). Any query text change is a hard requirement to port.
+2. **Endpoints & constants** — issuer `https://secure.scalable.capital` (`/oauth/device/code`, `/oauth/token`), GraphQL `https://de.scalable.capital/api/cli/graphql`, audience `https://de.scalable.capital/api-gateway`, client_id, scope. Upstream constant changes break login silently — check first.
+3. **Auth flow** — device-code polling states (`authorization_pending`, `slow_down`, `access_denied`, `expired_token`), refresh-token rotation (new refresh token must be persisted), claim extraction (`person_id`, `session_id`).
+4. **Retry semantics** — Rust wraps every GraphQL call in `execute_with_refresh_retry`: 401 → force session invalidation → re-login/refresh → retry once. Our equivalent is the attempt loop in `CliGraphqlClient.QueryAsync` (DPoP-nonce challenge first, then plain 401). Keep both layers.
+5. **Row mapping** — new transaction types, fee/tax/cash fields, overnight interest handling (`status` SETTLED/FILLED, cashTransactionType INTEREST/INTEREST_PAYMENT).
+
+### Phase 3: Port to C#
+
+- Follow repo conventions: tabs (width 4), CRLF, UTF-8, `TreatWarningsAsErrors=true`, nullability on.
+- Keep recovery paths self-healing: corrupt token file → broad catch → interactive re-login; corrupt signing key → broad catch → fresh key. Do not narrow these catches when porting.
+- Unknown transaction types: skip with `LogWarning` (matches Rust default unfiltered scrape — `type_filter`/`status` are optional user CLI args upstream, not defaults).
+
+### Phase 4: Validate
+
+1. `dotnet build` — 0 errors; baseline is 3 warnings (WASM0001 x2, ASPIRE010)
+2. `dotnet test` — all pass. **IntegrationTests need Docker Desktop running** (`docker info` to check; start via `Start-Process "C:\Program Files\Docker\Docker\Docker Desktop.exe"` if down). Full suite takes 3–5+ min — run async with long wait.
+3. Commit: caveman-commit style + `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer
+
+## Intentional Divergences (do NOT "fix")
+
+- **`ECDsa.SignData(data, HashAlgorithmName.SHA256)` is correct as-is.** On .NET 10 it returns raw `r||s` — exactly 64 bytes for P-256 — which IS the JWS ES256 format DPoP requires. Verified empirically (3 live BuildProof calls, first byte never `0x30`). The `DSASignatureFormat.Raw` enum member does not exist in this SDK; any "fix" toward DER encoding breaks login.
+- **DPoP proof header embeds the full JWK** (`kty`, `crv`, `x`, `y`) — matches upstream software-key behavior, required because we have no server-side key registration.
+- **Key/token files under `%LOCALAPPDATA%\GhostfolioSidekick\`**: `cli-auth-signing-key.json` (minimal JWK kty/crv/d), `cli-tokens.json`. Broad-catch self-heal on load is deliberate.
+- **No Windows binary concern** — we are the implementation; upstream platform-specific code (e.g. browser-open, OS keyring) maps to our console + file-based equivalents.
+
+## Parity Reference
+
+`Tools/ScraperUtilities/Mcp/McpScraper.cs` is the fee/tax/cash mapping reference. If an upstream change alters how fees, taxes, or cash movements are derived, apply it to **both** `CliScraper.cs` and `McpScraper.cs` so menu options 2 and 3 produce identical results for the same data.
+
+## Boundaries
+
+- Only touch `Tools/ScraperUtilities/CliApi/*`, `ScraperService.cs` wiring, and (for mapping parity) `Mcp/McpScraper.cs`.
+- Do not vendor Rust source into this repo — fetch to session workspace only.
+- If upstream changes the OAuth client_id or flow fundamentally (e.g. new grant type), flag it for user review before porting — that is a breaking change, not a sync.

--- a/Tools/ScraperUtilities/CliApi/CliGraphqlClient.cs
+++ b/Tools/ScraperUtilities/CliApi/CliGraphqlClient.cs
@@ -1,0 +1,111 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
+{
+	/// <summary>
+	/// Minimal GraphQL client for the Scalable Capital CLI API endpoint, using DPoP-protected access tokens.
+	/// Mirrors the official scalable-cli retry policy: one retry with a fresh nonce on a DPoP challenge.
+	/// </summary>
+	public class CliGraphqlClient : IDisposable
+	{
+		private static readonly Uri Endpoint = new("https://de.scalable.capital/api/cli/graphql");
+
+		private readonly HttpClient _httpClient;
+		private readonly DpopKey _dpopKey;
+		private readonly CliTokenProvider _tokenProvider;
+
+		public CliGraphqlClient(HttpClient httpClient, DpopKey dpopKey, CliTokenProvider tokenProvider)
+		{
+			_httpClient = httpClient;
+			_dpopKey = dpopKey;
+			_tokenProvider = tokenProvider;
+		}
+
+		public async Task<JsonNode> QueryAsync(string query, object? variables, string operationName, CancellationToken cancellationToken)
+		{
+			string? nonce = null;
+			for (var attempt = 0; attempt < 2; attempt++)
+			{
+				var body = new JsonObject
+				{
+					["query"] = query,
+					["variables"] = variables is null ? new JsonObject() : JsonSerializer.SerializeToNode(variables)!,
+					["operationName"] = operationName
+				};
+
+				using var content = new StringContent(body.ToJsonString(), System.Text.Encoding.UTF8, "application/json");
+				using var request = new HttpRequestMessage(HttpMethod.Post, Endpoint) { Content = content };
+				var session = await _tokenProvider.GetSessionAsync(cancellationToken);
+				request.Headers.Add("Authorization", $"DPoP {session.AccessToken}");
+				request.Headers.Add("DPoP", _dpopKey.BuildProof("POST", Endpoint, nonce, session.AccessToken));
+
+				string responseBody;
+				HttpResponseMessage? response = null;
+				try
+				{
+					response = await _httpClient.SendAsync(request, cancellationToken);
+					responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+					if (response.IsSuccessStatusCode)
+					{
+						return ParseData(responseBody, operationName);
+					}
+
+					var retryNonce = GetDpopNonce(response.Headers);
+					if (attempt == 0 && ShouldRetryWithDpopNonce((int)response.StatusCode, retryNonce, responseBody))
+					{
+						nonce = retryNonce;
+						continue;
+					}
+
+					throw new CliApiException($"GraphQL HTTP error {(int)response.StatusCode} during {operationName}: {responseBody}");
+				}
+				finally
+				{
+					response?.Dispose();
+				}
+			}
+
+			throw new InvalidOperationException("Unreachable DPoP retry loop exit.");
+		}
+
+		private static JsonNode ParseData(string responseBody, string operationName)
+		{
+			JsonNode? node;
+			try
+			{
+				node = JsonNode.Parse(responseBody);
+			}
+			catch (JsonException ex)
+			{
+				throw new CliApiException($"GraphQL response for {operationName} is not valid JSON: {responseBody}", ex);
+			}
+
+			var errors = node?["errors"]?.AsArray();
+			if (errors != null && errors.Count > 0)
+			{
+				var message = string.Join("; ", errors.Select(e => e?["message"]?.ToString() ?? "unknown error"));
+				throw new CliApiException($"GraphQL error during {operationName}: {message}");
+			}
+
+			return node?["data"] ?? throw new CliApiException($"GraphQL response for {operationName} has no data.");
+		}
+
+		private static string? GetDpopNonce(HttpResponseHeaders headers) =>
+			headers.TryGetValues("DPoP-Nonce", out var values) ? values.FirstOrDefault() : null;
+
+		private static bool ShouldRetryWithDpopNonce(int statusCode, string? nonce, string body)
+		{
+			if (string.IsNullOrWhiteSpace(nonce))
+			{
+				return false;
+			}
+
+			var lower = body.ToLowerInvariant();
+			return statusCode == 401 || lower.Contains("use_dpop_nonce") || lower.Contains("invalid_dpop_proof");
+		}
+
+		public void Dispose() => _dpopKey.Dispose();
+	}
+}

--- a/Tools/ScraperUtilities/CliApi/CliGraphqlClient.cs
+++ b/Tools/ScraperUtilities/CliApi/CliGraphqlClient.cs
@@ -26,6 +26,7 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 		public async Task<JsonNode> QueryAsync(string query, object? variables, string operationName, CancellationToken cancellationToken)
 		{
 			string? nonce = null;
+			var session = await _tokenProvider.GetSessionAsync(cancellationToken);
 			for (var attempt = 0; attempt < 2; attempt++)
 			{
 				var body = new JsonObject
@@ -37,7 +38,6 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 
 				using var content = new StringContent(body.ToJsonString(), System.Text.Encoding.UTF8, "application/json");
 				using var request = new HttpRequestMessage(HttpMethod.Post, Endpoint) { Content = content };
-				var session = await _tokenProvider.GetSessionAsync(cancellationToken);
 				request.Headers.Add("Authorization", $"DPoP {session.AccessToken}");
 				request.Headers.Add("DPoP", _dpopKey.BuildProof("POST", Endpoint, nonce, session.AccessToken));
 
@@ -56,6 +56,14 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 					if (attempt == 0 && ShouldRetryWithDpopNonce((int)response.StatusCode, retryNonce, responseBody))
 					{
 						nonce = retryNonce;
+						continue;
+					}
+
+					if (attempt == 0 && response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+					{
+						// Access token expired mid-scrape: force refresh and retry once (parity with scalable-cli execute_with_refresh_retry).
+						_tokenProvider.InvalidateSession();
+						session = await _tokenProvider.GetSessionAsync(cancellationToken);
 						continue;
 					}
 

--- a/Tools/ScraperUtilities/CliApi/CliGraphqlClient.cs
+++ b/Tools/ScraperUtilities/CliApi/CliGraphqlClient.cs
@@ -25,8 +25,23 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 
 		public async Task<JsonNode> QueryAsync(string query, object? variables, string operationName, CancellationToken cancellationToken)
 		{
-			string? nonce = null;
 			var session = await _tokenProvider.GetSessionAsync(cancellationToken);
+			try
+			{
+				return await ExecuteWithSessionAsync(session, query, variables, operationName, cancellationToken);
+			}
+			catch (CliApiException ex) when (IsUnauthorizedError(ex))
+			{
+				// Parity with scalable-cli execute_with_refresh_retry: the nonce budget is exhausted and the access token itself was rejected; force-refresh and re-run once.
+				_tokenProvider.InvalidateSession();
+				session = await _tokenProvider.GetSessionAsync(cancellationToken);
+				return await ExecuteWithSessionAsync(session, query, variables, operationName, cancellationToken);
+			}
+		}
+
+		private async Task<JsonNode> ExecuteWithSessionAsync(CliAuthSession session, string query, object? variables, string operationName, CancellationToken cancellationToken)
+		{
+			string? nonce = null;
 			for (var attempt = 0; attempt < 2; attempt++)
 			{
 				var body = new JsonObject
@@ -59,15 +74,7 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 						continue;
 					}
 
-					if (attempt == 0 && response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
-					{
-						// Access token expired mid-scrape: force refresh and retry once (parity with scalable-cli execute_with_refresh_retry).
-						_tokenProvider.InvalidateSession();
-						session = await _tokenProvider.GetSessionAsync(cancellationToken);
-						continue;
-					}
-
-					throw new CliApiException($"GraphQL HTTP error {(int)response.StatusCode} during {operationName}: {responseBody}");
+					throw new CliApiException($"GraphQL HTTP error {(int)response.StatusCode} during {operationName}: {responseBody}", (int)response.StatusCode, responseBody);
 				}
 				finally
 				{
@@ -94,7 +101,7 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 			if (errors != null && errors.Count > 0)
 			{
 				var message = string.Join("; ", errors.Select(e => e?["message"]?.ToString() ?? "unknown error"));
-				throw new CliApiException($"GraphQL error during {operationName}: {message}");
+				throw new CliApiException($"GraphQL error during {operationName}: {message}", responseBody);
 			}
 
 			return node?["data"] ?? throw new CliApiException($"GraphQL response for {operationName} has no data.");
@@ -113,6 +120,10 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 			var lower = body.ToLowerInvariant();
 			return statusCode == 401 || lower.Contains("use_dpop_nonce") || lower.Contains("invalid_dpop_proof");
 		}
+
+		private static bool IsUnauthorizedError(CliApiException ex) =>
+			ex.StatusCode == 401 ||
+			(ex.ResponseBody is not null && (ex.ResponseBody.Contains("UNAUTHENTICATED") || ex.ResponseBody.Contains("Missing or invalid credentials")));
 
 		public void Dispose() => _dpopKey.Dispose();
 	}

--- a/Tools/ScraperUtilities/CliApi/CliScraper.cs
+++ b/Tools/ScraperUtilities/CliApi/CliScraper.cs
@@ -310,10 +310,6 @@ query OvernightTransactions(
 		{
 			var session = await _tokenProvider.GetSessionAsync(cancellationToken);
 			var portfolioIds = await ResolveBrokerPortfolioIdsAsync(session.PersonId, cancellationToken);
-			if (portfolioIds.Count == 0)
-			{
-				throw new CliApiException("No accessible Scalable Capital portfolios were returned by the CLI API.");
-			}
 
 			var result = new Dictionary<int, IEnumerable<ActivityWithSymbol>>();
 			var index = 0;
@@ -330,6 +326,11 @@ query OvernightTransactions(
 				index++;
 				_logger.LogInformation("Scraping Scalable Capital overnight transactions for savings account {Name} ({SavingsAccountId})", name, savingsAccountId);
 				result[index] = await ScrapeOvernightAccountAsync(session.PersonId, savingsAccountId, cancellationToken);
+			}
+
+			if (result.Count == 0)
+			{
+				throw new CliApiException("No accessible Scalable Capital portfolios or overnight accounts were returned by the CLI API.");
 			}
 
 			return result;

--- a/Tools/ScraperUtilities/CliApi/CliScraper.cs
+++ b/Tools/ScraperUtilities/CliApi/CliScraper.cs
@@ -1,0 +1,731 @@
+using System.Globalization;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using GhostfolioSidekick.Model;
+using GhostfolioSidekick.Model.Activities;
+using GhostfolioSidekick.Model.Activities.Types;
+using GhostfolioSidekick.Tools.ScraperUtilities;
+
+namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
+{
+	/// <summary>
+	/// Scrapes Scalable Capital transactions via the official CLI API (same GraphQL endpoint as scalable-cli).
+	/// Unlike the MCP server, this path also returns overnight savings-account interest.
+	/// Produces the same output contract as the other scrapers: account index to activities.
+	/// </summary>
+	public class CliScraper
+	{
+		private const int PageSize = 100;
+
+		private static readonly string ResolveBrokerIdsQuery = @"
+query ResolveBrokerIds($id: ID!) {
+  account(id: $id) {
+    id
+    brokerPortfolios {
+      id
+    }
+  }
+}";
+
+		private static readonly string BrokerTransactionsQuery = @"
+query BrokerTransactions($accountId: ID!, $portfolioId: ID!, $input: BrokerTransactionInput!) {
+  account(id: $accountId) {
+    brokerPortfolio(id: $portfolioId) {
+      moreTransactions(input: $input) {
+        cursor
+        total
+        transactions {
+          __typename
+          id
+          currency
+          type
+          status
+          isCancellation
+          lastEventDateTime
+          description
+          custodian
+          documents {
+            id
+            url
+            label
+          }
+          ... on BrokerSecurityTransactionSummary {
+            isin
+            securityTransactionType
+            quantity
+            amount
+            side
+            limitPrice
+            stopPrice
+          }
+          ... on BrokerCashTransactionSummary {
+            relatedIsin
+            cashTransactionType
+            amount
+          }
+          ... on BrokerNonTradeSecurityTransactionSummary {
+            isin
+            nonTradeSecurityTransactionType
+            quantity
+            amount
+          }
+          ... on BrokerEltifTransactionSummary {
+            isin
+            securityTransactionType
+            eltifQuantity
+            amount
+            side
+          }
+        }
+      }
+    }
+  }
+}";
+
+		private static readonly string BrokerTransactionDetailsQuery = @"
+query BrokerTransactionDetails($accountId: ID!, $portfolioId: ID!, $transactionId: ID!) {
+  account(id: $accountId) {
+    brokerPortfolio(id: $portfolioId) {
+      transactionDetails(id: $transactionId) {
+        __typename
+        id
+        currency
+        type
+        documents {
+          id
+          url
+          label
+        }
+        lastEventDateTime
+        isPending
+        isCancellation
+        security {
+          isin
+          name
+          type
+        }
+        transactionReference
+        ... on BrokerSecurityTransaction {
+          side
+          status
+          numberOfShares {
+            filled
+            total
+          }
+          averagePrice
+          totalAmount
+          finalisationReason
+          limitPrice
+          stopPrice
+          validUntil
+          isCancellationRequested
+          tradeTransactionAmounts {
+            marketValuation
+            taxAmount
+            transactionFee
+            venueFee
+            cryptoSpreadFee
+          }
+          tradingVenue
+          fee
+          transactionalFee
+          taxes
+          aggregatedTransactionTaxes {
+            totalTax
+            capitalGainsTax
+            churchTax
+            solidarityTax
+            sourceTax
+            financialTransactionTax
+          }
+          securityTransactionHistory: transactionHistory {
+            state
+            time {
+              time
+              epochSecond
+              epochMillisecond
+            }
+            numberOfShares {
+              filled
+              total
+            }
+            executionPrice
+          }
+          orderKind
+          linkedTransactions {
+            id
+          }
+          trailingStopInfo {
+            trailType
+            trailOffset
+            latestStopPriceTimestamp {
+              time
+              epochSecond
+              epochMillisecond
+            }
+          }
+        }
+        ... on BrokerCashTransaction {
+          cashTransactionType
+          amount
+          description
+          cashTransactionHistory: transactionHistory {
+            state
+            time {
+              time
+              epochSecond
+              epochMillisecond
+            }
+          }
+          sddiDetails {
+            fee
+            grossAmount
+          }
+          taxDetails {
+            grossAmount
+            taxAmount
+          }
+          linkedTransactions {
+            id
+          }
+        }
+        ... on BrokerNonTradeSecurityTransaction {
+          isin
+          nonTradeSecurityTransactionType
+          quantity
+          nonTradeAveragePrice: averagePrice
+          nonTradeSecurityAmount: totalAmount
+          description
+          nonTradeSecurityTransactionHistory: transactionHistory {
+            state
+            time {
+              time
+              epochSecond
+              epochMillisecond
+            }
+          }
+          linkedTransactions {
+            id
+          }
+        }
+        ... on BrokerEltifTransaction {
+          status
+          side
+          orderKind
+          amount
+          finalisationReason
+          eltifQuantity
+          executionPrice
+          executionDate
+          earliestSellDate
+          marketValuation
+          cancelableDetails {
+            daysLeft
+            isCancelable
+          }
+          isMultipleOrdersCancellation
+          isInitialInvestment
+          tradingVenue
+          eltifTransactionHistory: transactionHistory {
+            state
+            amount
+            eltifQuantity
+            executionPrice
+            time {
+              time
+              epochSecond
+              epochMillisecond
+            }
+          }
+          linkedTransactions {
+            id
+          }
+        }
+      }
+    }
+  }
+}";
+
+		private static readonly string DiscoverOvernightAccountsQuery = @"
+query DiscoverOvernightAccounts($accountId: ID!) {
+  account(id: $accountId) {
+    savingsAccounts {
+      __typename
+      id
+      personalizations {
+        name
+      }
+      state
+    }
+  }
+}";
+
+		private static readonly string OvernightTransactionsQuery = @"
+query OvernightTransactions(
+  $accountId: ID!
+  $savingsAccountId: ID!
+  $input: SavingsAccountCashTransactionInput!
+) {
+  account(id: $accountId) {
+    savingsAccount(id: $savingsAccountId) {
+      id
+      moreTransactions(input: $input) {
+        cursor
+        total
+        transactions {
+          id
+          currency
+          type
+          status
+          isCancellation
+          lastEventDateTime
+          description
+          cashTransactionType
+          amount
+          custodian
+          relatedIsin
+          documents {
+            id
+            label
+            url
+          }
+        }
+      }
+    }
+  }
+}";
+
+		private readonly CliGraphqlClient _client;
+		private readonly CliTokenProvider _tokenProvider;
+		private readonly ILogger _logger;
+
+		public CliScraper(CliGraphqlClient client, CliTokenProvider tokenProvider, ILogger logger)
+		{
+			_client = client;
+			_tokenProvider = tokenProvider;
+			_logger = logger;
+		}
+
+		public async Task<Dictionary<int, IEnumerable<ActivityWithSymbol>>> ScrapeTransactionsAsync(CancellationToken cancellationToken)
+		{
+			var session = await _tokenProvider.GetSessionAsync(cancellationToken);
+			var portfolioIds = await ResolveBrokerPortfolioIdsAsync(session.PersonId, cancellationToken);
+			if (portfolioIds.Count == 0)
+			{
+				throw new CliApiException("No accessible Scalable Capital portfolios were returned by the CLI API.");
+			}
+
+			var result = new Dictionary<int, IEnumerable<ActivityWithSymbol>>();
+			var index = 0;
+			foreach (var portfolioId in portfolioIds)
+			{
+				index++;
+				_logger.LogInformation("Scraping Scalable Capital CLI transactions for portfolio {PortfolioId}", portfolioId);
+				result[index] = await ScrapeBrokerPortfolioAsync(session.PersonId, portfolioId, cancellationToken);
+			}
+
+			var savingsAccounts = await DiscoverOvernightSavingsAccountsAsync(session.PersonId, cancellationToken);
+			foreach (var (savingsAccountId, name) in savingsAccounts)
+			{
+				index++;
+				_logger.LogInformation("Scraping Scalable Capital overnight transactions for savings account {Name} ({SavingsAccountId})", name, savingsAccountId);
+				result[index] = await ScrapeOvernightAccountAsync(session.PersonId, savingsAccountId, cancellationToken);
+			}
+
+			return result;
+		}
+
+		private async Task<List<string>> ResolveBrokerPortfolioIdsAsync(string personId, CancellationToken cancellationToken)
+		{
+			var data = await _client.QueryAsync(ResolveBrokerIdsQuery, new JsonObject { ["id"] = personId }, "ResolveBrokerIds", cancellationToken);
+			var portfolios = data["account"]?["brokerPortfolios"]?.AsArray();
+
+			return (portfolios ?? Enumerable.Empty<JsonNode?>())
+				.Select(p => p?["id"]?.ToString())
+				.Where(id => !string.IsNullOrWhiteSpace(id))
+				.Select(id => id!)
+				.ToList();
+		}
+
+		private async Task<List<(string Id, string Name)>> DiscoverOvernightSavingsAccountsAsync(string personId, CancellationToken cancellationToken)
+		{
+			var data = await _client.QueryAsync(DiscoverOvernightAccountsQuery, new JsonObject { ["accountId"] = personId }, "DiscoverOvernightAccounts", cancellationToken);
+			var accounts = data["account"]?["savingsAccounts"]?.AsArray();
+
+			var result = new List<(string Id, string Name)>();
+			foreach (var account in accounts ?? Enumerable.Empty<JsonNode?>())
+			{
+				if (account is not JsonObject item)
+				{
+					continue;
+				}
+
+				if (item["state"]?.ToString() != "ACTIVE")
+				{
+					continue;
+				}
+
+				var id = item["id"]?.ToString();
+				if (string.IsNullOrWhiteSpace(id))
+				{
+					continue;
+				}
+
+				result.Add((id!, item["personalizations"]?["name"]?.ToString() ?? string.Empty));
+			}
+
+			return result;
+		}
+
+		private async Task<List<ActivityWithSymbol>> ScrapeBrokerPortfolioAsync(string personId, string portfolioId, CancellationToken cancellationToken)
+		{
+			var transactions = new List<JsonObject>();
+			string? cursor = null;
+
+			do
+			{
+				var input = new JsonObject { ["pageSize"] = PageSize };
+				if (cursor != null)
+				{
+					input["cursor"] = cursor;
+				}
+
+				var variables = new JsonObject
+				{
+					["accountId"] = personId,
+					["portfolioId"] = portfolioId,
+					["input"] = input
+				};
+
+				var data = await _client.QueryAsync(BrokerTransactionsQuery, variables, "BrokerTransactions", cancellationToken);
+				var moreTransactions = data["account"]?["brokerPortfolio"]?["moreTransactions"];
+				foreach (var transaction in moreTransactions?["transactions"]?.AsArray() ?? Enumerable.Empty<JsonNode?>())
+				{
+					if (transaction is JsonObject item)
+					{
+						transactions.Add(item);
+					}
+				}
+
+				cursor = moreTransactions?["cursor"]?.ToString();
+			} while (!string.IsNullOrWhiteSpace(cursor));
+
+			var activities = new List<ActivityWithSymbol>();
+			foreach (var transaction in transactions)
+			{
+				try
+				{
+					var activity = await MapBrokerTransactionAsync(personId, portfolioId, transaction, cancellationToken);
+					if (activity != null)
+					{
+						activities.Add(activity);
+					}
+				}
+				catch (CliApiException ex)
+				{
+					_logger.LogWarning(ex, "Skipping CLI transaction {TransactionId}: {Message}", transaction["id"]?.ToString(), ex.Message);
+				}
+			}
+
+			return activities;
+		}
+
+		private async Task<ActivityWithSymbol?> MapBrokerTransactionAsync(string personId, string portfolioId, JsonObject entry, CancellationToken cancellationToken)
+		{
+			var id = entry["id"]?.ToString();
+			if (string.IsNullOrWhiteSpace(id))
+			{
+				return null;
+			}
+
+			var status = entry["status"]?.ToString() ?? string.Empty;
+			if (status is not ("SETTLED" or "FILLED"))
+			{
+				_logger.LogDebug("Skipping CLI transaction {TransactionId} with status {Status}", id, status);
+				return null;
+			}
+
+			var variables = new JsonObject
+			{
+				["accountId"] = personId,
+				["portfolioId"] = portfolioId,
+				["transactionId"] = id
+			};
+
+			var data = await _client.QueryAsync(BrokerTransactionDetailsQuery, variables, "BrokerTransactionDetails", cancellationToken);
+			if (data["account"]?["brokerPortfolio"]?["transactionDetails"] is not JsonObject detail)
+			{
+				throw new CliApiException($"Transaction {id} has no detail payload.");
+			}
+
+			var typename = detail["__typename"]?.ToString() ?? "unknown";
+			return typename switch
+			{
+				"BrokerSecurityTransaction" => MapSecurityTrade(detail),
+				"BrokerCashTransaction" => MapCashTransaction(id, entry, detail),
+				_ => throw new CliApiException($"Unknown transaction type '{typename}'.")
+			};
+		}
+
+		private ActivityWithSymbol MapSecurityTrade(JsonObject detail)
+		{
+			var security = detail["security"];
+			var isin = security?["isin"]?.ToString();
+			if (string.IsNullOrWhiteSpace(isin))
+			{
+				throw new CliApiException("Security transaction has no ISIN.");
+			}
+
+			var side = detail["side"]?.ToString() ?? string.Empty;
+			var quantity = ParseDecimal(detail["numberOfShares"]?["filled"]);
+			var unitPrice = ParseMoney(detail["averagePrice"], detail);
+			if (quantity is null || quantity <= 0m || unitPrice is null)
+			{
+				throw new CliApiException($"Security transaction {detail["id"]} has no filled quantity or price.");
+			}
+
+			var date = GetFilledDate(detail, "securityTransactionHistory");
+			var currency = detail["currency"]?.ToString() ?? "EUR";
+			var fees = CollectAmounts(currency, detail["fee"], detail["transactionalFee"], detail["tradeTransactionAmounts"]?["transactionFee"], detail["tradeTransactionAmounts"]?["venueFee"]);
+			var taxes = CollectAmounts(currency, detail["taxes"], detail["tradeTransactionAmounts"]?["taxAmount"]);
+
+			Activity activity = side switch
+			{
+				"BUY" => new BuyActivity { Quantity = quantity.Value, UnitPrice = unitPrice, Fees = fees, Taxes = taxes, Date = date, TransactionId = detail["id"]?.ToString() ?? string.Empty },
+				"SELL" => new SellActivity { Quantity = quantity.Value, UnitPrice = unitPrice, Fees = fees, Taxes = taxes, Date = date, TransactionId = detail["id"]?.ToString() ?? string.Empty },
+				_ => throw new CliApiException($"Unknown trade side '{side}'.")
+			};
+
+			return new ActivityWithSymbol
+			{
+				Activity = activity,
+				Symbol = isin,
+				SymbolName = security?["name"]?.ToString(),
+				ISIN = isin
+			};
+		}
+
+		private ActivityWithSymbol? MapCashTransaction(string id, JsonObject listEntry, JsonObject detail)
+		{
+			var type = detail["cashTransactionType"]?.ToString() ?? string.Empty;
+			var amount = ParseMoney(detail["amount"], detail);
+			if (amount is null)
+			{
+				throw new CliApiException($"Cash transaction {id} has no amount.");
+			}
+
+			var date = GetFilledDate(detail, "cashTransactionHistory");
+			var description = detail["description"]?.ToString() ?? listEntry["description"]?.ToString();
+			var relatedIsin = detail["relatedIsin"]?.ToString() ?? listEntry["relatedIsin"]?.ToString();
+			return BuildCashActivity(id, type, amount, date, description, relatedIsin);
+		}
+
+		private async Task<List<ActivityWithSymbol>> ScrapeOvernightAccountAsync(string personId, string savingsAccountId, CancellationToken cancellationToken)
+		{
+			var transactions = new List<JsonObject>();
+			string? cursor = null;
+
+			do
+			{
+				var input = new JsonObject { ["pageSize"] = PageSize };
+				if (cursor != null)
+				{
+					input["cursor"] = cursor;
+				}
+
+				var variables = new JsonObject
+				{
+					["accountId"] = personId,
+					["savingsAccountId"] = savingsAccountId,
+					["input"] = input
+				};
+
+				var data = await _client.QueryAsync(OvernightTransactionsQuery, variables, "OvernightTransactions", cancellationToken);
+				var moreTransactions = data["account"]?["savingsAccount"]?["moreTransactions"];
+				foreach (var transaction in moreTransactions?["transactions"]?.AsArray() ?? Enumerable.Empty<JsonNode?>())
+				{
+					if (transaction is JsonObject item)
+					{
+						transactions.Add(item);
+					}
+				}
+
+				cursor = moreTransactions?["cursor"]?.ToString();
+			} while (!string.IsNullOrWhiteSpace(cursor));
+
+			var activities = new List<ActivityWithSymbol>();
+			foreach (var transaction in transactions)
+			{
+				try
+				{
+					var activity = MapOvernightTransaction(transaction);
+					if (activity != null)
+					{
+						activities.Add(activity);
+					}
+				}
+				catch (CliApiException ex)
+				{
+					_logger.LogWarning(ex, "Skipping CLI overnight transaction {TransactionId}: {Message}", transaction["id"]?.ToString(), ex.Message);
+				}
+			}
+
+			return activities;
+		}
+
+		private ActivityWithSymbol? MapOvernightTransaction(JsonObject entry)
+		{
+			var id = entry["id"]?.ToString();
+			if (string.IsNullOrWhiteSpace(id))
+			{
+				return null;
+			}
+
+			var status = entry["status"]?.ToString() ?? string.Empty;
+			if (status is not ("SETTLED" or "FILLED"))
+			{
+				_logger.LogDebug("Skipping CLI overnight transaction {TransactionId} with status {Status}", id, status);
+				return null;
+			}
+
+			var type = entry["cashTransactionType"]?.ToString() ?? string.Empty;
+			var amount = ParseMoney(entry["amount"], entry);
+			if (amount is null)
+			{
+				throw new CliApiException($"Overnight transaction {id} has no amount.");
+			}
+
+			if (!TryParseDate(entry["lastEventDateTime"]?.ToString(), out var date))
+			{
+				throw new CliApiException($"Overnight transaction {id} has no parseable timestamp.");
+			}
+
+			return BuildCashActivity(id!, type, amount, date, entry["description"]?.ToString(), entry["relatedIsin"]?.ToString());
+		}
+
+		private ActivityWithSymbol? BuildCashActivity(string id, string type, Money amount, DateTime date, string? description, string? relatedIsin)
+		{
+			Activity? activity = type switch
+			{
+				"DEPOSIT" => new CashDepositActivity { Amount = amount, Date = date, TransactionId = id },
+				"WITHDRAWAL" => new CashWithdrawalActivity { Amount = amount, Date = date, TransactionId = id },
+				"DISTRIBUTION" => new DividendActivity { Amount = amount, Quantity = 0m, Fees = [], Taxes = [], Date = date, TransactionId = id },
+				"CASH_TRANSFER_OUT" => null,
+				"INTEREST" or "INTEREST_PAYMENT" => new InterestActivity { Amount = amount, Date = date, TransactionId = id },
+				_ => null
+			};
+
+			if (activity is null)
+			{
+				_logger.LogWarning("Ignoring unsupported CLI cash transaction type '{Type}' ({TransactionId})", type, id);
+				return null;
+			}
+
+			return new ActivityWithSymbol
+			{
+				Activity = activity,
+				Symbol = string.IsNullOrWhiteSpace(relatedIsin) ? default! : relatedIsin,
+				SymbolName = description,
+				ISIN = string.IsNullOrWhiteSpace(relatedIsin) ? null : relatedIsin
+			};
+		}
+
+		private static DateTime GetFilledDate(JsonObject detail, string historyKey)
+		{
+			var history = detail[historyKey]?.AsArray();
+			if (history != null)
+			{
+				foreach (var state in new[] { "FILLED", "SETTLED" })
+				{
+					var entry = history.FirstOrDefault(h => h?["state"]?.ToString() == state);
+					if (entry is not null && TryParseDate(entry?["time"]?["time"]?.ToString(), out var date))
+					{
+						return date;
+					}
+				}
+
+				foreach (var entry in history)
+				{
+					if (TryParseDate(entry?["time"]?["time"]?.ToString(), out var date))
+					{
+						return date;
+					}
+				}
+			}
+
+			if (TryParseDate(detail["lastEventDateTime"]?.ToString(), out var lastEventAt))
+			{
+				return lastEventAt;
+			}
+
+			throw new CliApiException($"Transaction {detail["id"]} has no parseable timestamp.");
+		}
+
+		private static bool TryParseDate(string? value, out DateTime date)
+		{
+			date = default;
+			if (string.IsNullOrWhiteSpace(value))
+			{
+				return false;
+			}
+
+			var formats = new[] { "yyyy-MM-dd'T'HH:mm:ss", "dd/MM/yyyy HH:mm:ss" };
+			if (DateTime.TryParseExact(value, formats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var exact))
+			{
+				date = exact;
+				return true;
+			}
+
+			// Wall-clock parity with the other scraper paths: no timezone conversion for local timestamps; Z-suffixed UTC values convert to UTC.
+			return DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out date);
+		}
+
+		private static List<Money> CollectAmounts(string currency, params JsonNode?[] nodes)
+		{
+			var result = new List<Money>();
+			foreach (var node in nodes)
+			{
+				if (node is null || node.GetValueKind() == System.Text.Json.JsonValueKind.Null)
+				{
+					continue;
+				}
+
+				var value = ParseDecimal(node);
+				if (value is not null && value.Value != 0m)
+				{
+					result.Add(new Money(currency, value.Value));
+				}
+			}
+
+			return result;
+		}
+
+		private static decimal? ParseDecimal(JsonNode? node)
+		{
+			var text = node?.ToString();
+			if (string.IsNullOrWhiteSpace(text))
+			{
+				return null;
+			}
+
+			return decimal.TryParse(text, NumberStyles.Number, CultureInfo.InvariantCulture, out var value) ? value : null;
+		}
+
+		private static Money? ParseMoney(JsonNode? node, JsonObject detail)
+		{
+			var text = node?.ToString();
+			if (string.IsNullOrWhiteSpace(text))
+			{
+				return null;
+			}
+
+			if (!decimal.TryParse(text, NumberStyles.Number, CultureInfo.InvariantCulture, out var value))
+			{
+				throw new CliApiException($"Transaction {detail["id"]} has unparseable amount '{text}'.");
+			}
+
+			var currency = detail["currency"]?.ToString() ?? "EUR";
+			return new Money(currency, value);
+		}
+	}
+}

--- a/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
+++ b/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
@@ -314,8 +314,9 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 				File.WriteAllText(path, key.ToJson());
 				return key;
 			}
-			catch (IOException)
+			catch (Exception ex) when (ex is IOException or InvalidOperationException or JsonException)
 			{
+				// Corrupt or unreadable key file: start fresh. The DPoP key is self-describing in every proof, so rotation is safe.
 				return DpopKey.Create();
 			}
 		}
@@ -326,9 +327,10 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 			{
 				Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
 			}
-			catch (Exception ex)
+			catch (Exception)
 			{
-				throw new CliApiException($"Could not open the default browser. Open this URL manually to complete the login: {url}", ex);
+				Console.WriteLine("Could not open the default browser automatically. Open this URL manually to complete the login:");
+				Console.WriteLine(url);
 			}
 		}
 

--- a/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
+++ b/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
@@ -1,0 +1,368 @@
+using System.Diagnostics;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
+{
+	/// <summary>
+	/// Provides authenticated sessions for the Scalable Capital CLI API (same flow as the official scalable-cli):
+	/// device-code login on first use, refresh-token rotation afterwards. Tokens are persisted in %LOCALAPPDATA%.
+	/// </summary>
+	public class CliTokenProvider : IDisposable
+	{
+		private const string ClientId = "yBM3BrpRgwSTJZRdJllvtD6jJEmyxWfE";
+		private const string Audience = "https://de.scalable.capital/api-gateway";
+		private const string Scope = "offline_access openid email";
+
+		private static readonly Uri Issuer = new("https://secure.scalable.capital");
+
+		private readonly HttpClient _httpClient;
+		private readonly ILogger _logger;
+		private readonly CliTokenStore _store;
+		private readonly DpopKey _dpopKey;
+		private readonly object _lock = new();
+		private CliAuthSession? _session;
+
+		public DpopKey Key => _dpopKey;
+
+		public CliTokenProvider(HttpClient httpClient, ILogger logger)
+			: this(httpClient, logger, new CliTokenStore(), LoadOrCreateDpopKey())
+		{
+		}
+
+		internal CliTokenProvider(HttpClient httpClient, ILogger logger, CliTokenStore store, DpopKey dpopKey)
+		{
+			_httpClient = httpClient;
+			_logger = logger;
+			_store = store;
+			_dpopKey = dpopKey;
+		}
+
+		public async Task<CliAuthSession> GetSessionAsync(CancellationToken cancellationToken)
+		{
+			lock (_lock)
+			{
+				if (_session != null && _session.ExpiresAtUtc > DateTime.UtcNow.AddSeconds(60))
+				{
+					return _session;
+				}
+			}
+
+			var stored = _store.Load();
+			if (stored is not null)
+			{
+				try
+				{
+					await RefreshAsync(stored, cancellationToken);
+					return _session!;
+				}
+				catch (CliApiException ex)
+				{
+					_logger.LogWarning(ex, "Stored CLI API refresh token is no longer valid; falling back to device-code login.");
+				}
+			}
+
+			await DeviceCodeLoginAsync(cancellationToken);
+			return _session!;
+		}
+
+		private async Task RefreshAsync(CliAuthSession stored, CancellationToken cancellationToken)
+		{
+			if (string.IsNullOrWhiteSpace(stored.RefreshToken))
+			{
+				throw new CliApiException("Stored CLI API session has no refresh token.");
+			}
+
+			var form = new Dictionary<string, string>
+			{
+				["grant_type"] = "refresh_token",
+				["client_id"] = ClientId,
+				["refresh_token"] = stored.RefreshToken
+			};
+
+			if (!string.IsNullOrWhiteSpace(stored.SessionId))
+			{
+				form["session_id"] = stored.SessionId;
+			}
+
+			var body = await PostFormAsync($"{Issuer}/oauth/token", form, null, cancellationToken);
+			await ApplyTokenResponseAsync(body, stored.PersonId, cancellationToken);
+		}
+
+		private async Task DeviceCodeLoginAsync(CancellationToken cancellationToken)
+		{
+			var startBody = await PostFormAsync($"{Issuer}/oauth/device/code", new Dictionary<string, string>
+			{
+				["client_id"] = ClientId,
+				["audience"] = Audience,
+				["scope"] = Scope
+			}, null, cancellationToken);
+
+			using var startDocument = JsonDocument.Parse(startBody);
+			var deviceCode = RequireString(startDocument.RootElement, "device_code");
+			var userCode = RequireString(startDocument.RootElement, "user_code");
+			var verificationUri = startDocument.RootElement.TryGetProperty("verification_uri_complete", out var complete) && !string.IsNullOrWhiteSpace(complete.GetString())
+				? complete.GetString()!
+				: RequireString(startDocument.RootElement, "verification_uri");
+			var expiresIn = startDocument.RootElement.TryGetProperty("expires_in", out var exp) ? exp.GetInt32() : 600;
+			var intervalSeconds = Math.Max(1, startDocument.RootElement.TryGetProperty("interval", out var interval) && interval.ValueKind == JsonValueKind.Number ? interval.GetInt32() : 5);
+
+			Console.WriteLine("Sign in to Scalable Capital:");
+			Console.WriteLine($"Open this URL: {verificationUri}");
+			Console.WriteLine($"Verify the code {userCode} in your browser.");
+			OpenBrowser(verificationUri);
+
+			var expiresAt = DateTime.UtcNow.AddSeconds(expiresIn);
+			while (true)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+				if (DateTime.UtcNow >= expiresAt)
+				{
+					throw new CliApiException("Device code login expired before completion.");
+				}
+
+				await Task.Delay(TimeSpan.FromSeconds(intervalSeconds), cancellationToken);
+
+				var form = new Dictionary<string, string>
+				{
+					["grant_type"] = "urn:ietf:params:oauth:grant-type:device_code",
+					["device_code"] = deviceCode,
+					["client_id"] = ClientId
+				};
+
+				try
+				{
+					var body = await PostFormAsync($"{Issuer}/oauth/token", form, null, cancellationToken);
+					await ApplyTokenResponseAsync(body, string.Empty, cancellationToken);
+					return;
+				}
+				catch (CliApiException ex) when (ex.StatusCode == 400 && !string.IsNullOrWhiteSpace(ex.ResponseBody))
+				{
+					var state = ParseOAuthError(ex.ResponseBody!);
+					if (state == "authorization_pending")
+					{
+						continue;
+					}
+
+					if (state == "slow_down")
+					{
+						intervalSeconds += 2;
+						Console.WriteLine($"Waiting for browser confirmation... (polling every {intervalSeconds}s)");
+						continue;
+					}
+
+					throw new CliApiException(state switch
+					{
+						"access_denied" => "Device login denied by user.",
+						"expired_token" => "Device login code expired.",
+						_ => $"Device code polling failed: {state}"
+					});
+				}
+			}
+		}
+
+		private async Task ApplyTokenResponseAsync(string body, string fallbackPersonId, CancellationToken cancellationToken)
+		{
+			using var document = JsonDocument.Parse(body);
+			var root = document.RootElement;
+			var accessToken = RequireString(root, "access_token");
+			var refreshToken = root.TryGetProperty("refresh_token", out var rt) ? rt.GetString() : null;
+			if (string.IsNullOrWhiteSpace(refreshToken))
+			{
+				throw new CliApiException("CLI API token endpoint returned no refresh token.");
+			}
+
+			var expiresAtUtc = DateTime.UtcNow.AddSeconds(root.TryGetProperty("expires_in", out var exp) && exp.ValueKind == JsonValueKind.Number ? exp.GetInt32() : 1200);
+			var claims = DecodeJwtClaims(accessToken);
+			var personId = FirstClaim(claims, "person_id", "https://de.scalable.capital/person_id", "https://de.scalable.capital/personId") ?? fallbackPersonId;
+			if (string.IsNullOrWhiteSpace(personId))
+			{
+				throw new CliApiException("CLI API access token does not contain a person_id claim.");
+			}
+
+			var sessionId = FirstClaim(claims, "session_id", "https://de.scalable.capital/session_id");
+			lock (_lock)
+			{
+				_session = new CliAuthSession(accessToken, refreshToken, expiresAtUtc, personId, sessionId);
+			}
+
+			try
+			{
+				_store.Save(_session!);
+			}
+			catch (IOException ex)
+			{
+				_logger.LogWarning(ex, "Could not persist CLI API tokens; a login may be required on the next run.");
+			}
+		}
+
+		private async Task<string> PostFormAsync(string url, Dictionary<string, string> form, string? accessToken, CancellationToken cancellationToken)
+		{
+			var uri = new Uri(url);
+			string? nonce = null;
+			for (var attempt = 0; attempt < 2; attempt++)
+			{
+				using var content = new FormUrlEncodedContent(form);
+				using var request = new HttpRequestMessage(HttpMethod.Post, uri) { Content = content };
+				request.Headers.Add("DPoP", _dpopKey.BuildProof("POST", uri, nonce, accessToken));
+
+				var response = await _httpClient.SendAsync(request, cancellationToken);
+				string responseBody;
+				try
+				{
+					responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+					if (response.IsSuccessStatusCode)
+					{
+						return responseBody;
+					}
+
+					var retryNonce = GetDpopNonce(response.Headers);
+					if (attempt == 0 && ShouldRetryWithDpopNonce((int)response.StatusCode, retryNonce, responseBody))
+					{
+						nonce = retryNonce;
+						continue;
+					}
+
+					throw new CliApiException($"CLI API HTTP error {(int)response.StatusCode}: {responseBody}", (int)response.StatusCode, responseBody);
+				}
+				finally
+				{
+					response.Dispose();
+				}
+			}
+
+			throw new InvalidOperationException("Unreachable DPoP retry loop exit.");
+		}
+
+		private static string? GetDpopNonce(HttpResponseHeaders headers) =>
+			headers.TryGetValues("DPoP-Nonce", out var values) ? values.FirstOrDefault() : null;
+
+		private static bool ShouldRetryWithDpopNonce(int statusCode, string? nonce, string body)
+		{
+			if (string.IsNullOrWhiteSpace(nonce))
+			{
+				return false;
+			}
+
+			var lower = body.ToLowerInvariant();
+			return statusCode == 401 || lower.Contains("use_dpop_nonce") || lower.Contains("invalid_dpop_proof");
+		}
+
+		private static string? ParseOAuthError(string body)
+		{
+			try
+			{
+				using var document = JsonDocument.Parse(body);
+				return document.RootElement.TryGetProperty("error", out var error) ? error.GetString() : null;
+			}
+			catch (JsonException)
+			{
+				return null;
+			}
+		}
+
+		private static Dictionary<string, JsonElement> DecodeJwtClaims(string jwt)
+		{
+			var parts = jwt.Split('.');
+			if (parts.Length < 2)
+			{
+				throw new CliApiException("CLI API access token is not a JWT.");
+			}
+
+			var payload = Encoding.UTF8.GetString(Base64UrlDecode(parts[1]));
+			using var document = JsonDocument.Parse(payload);
+			var claims = new Dictionary<string, JsonElement>();
+			foreach (var property in document.RootElement.EnumerateObject())
+			{
+				claims[property.Name] = property.Value.Clone();
+			}
+
+			return claims;
+		}
+
+		private static string? FirstClaim(Dictionary<string, JsonElement> claims, params string[] names)
+		{
+			foreach (var name in names)
+			{
+				if (claims.TryGetValue(name, out var value) && value.ValueKind == JsonValueKind.String)
+				{
+					return value.GetString();
+				}
+			}
+
+			return null;
+		}
+
+		private static string RequireString(JsonElement element, string name) =>
+			element.TryGetProperty(name, out var property) ? property.GetString() ?? throw new CliApiException($"CLI API response is missing '{name}'.") : throw new CliApiException($"CLI API response is missing '{name}'.");
+
+		private static DpopKey LoadOrCreateDpopKey()
+		{
+			var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "GhostfolioSidekick");
+			Directory.CreateDirectory(dir);
+			var path = Path.Combine(dir, "cli-auth-signing-key.json");
+			try
+			{
+				if (File.Exists(path))
+				{
+					return DpopKey.Load(File.ReadAllText(path));
+				}
+
+				var key = DpopKey.Create();
+				File.WriteAllText(path, key.ToJson());
+				return key;
+			}
+			catch (IOException)
+			{
+				return DpopKey.Create();
+			}
+		}
+
+		private static void OpenBrowser(string url)
+		{
+			try
+			{
+				Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+			}
+			catch (Exception ex)
+			{
+				throw new CliApiException($"Could not open the default browser. Open this URL manually to complete the login: {url}", ex);
+			}
+		}
+
+		private static byte[] Base64UrlDecode(string value)
+		{
+			var base64 = value.Replace('-', '+').Replace('_', '/');
+			return Convert.FromBase64String(base64.PadRight(base64.Length + (4 - base64.Length % 4) % 4, '='));
+		}
+
+		public void Dispose() => _dpopKey.Dispose();
+	}
+
+	public record CliAuthSession(string AccessToken, string? RefreshToken, DateTime ExpiresAtUtc, string PersonId, string? SessionId);
+
+	public class CliApiException : Exception
+	{
+		public int? StatusCode { get; }
+		public string? ResponseBody { get; }
+
+		public CliApiException(string message)
+			: base(message)
+		{
+		}
+
+		public CliApiException(string message, int statusCode, string responseBody)
+			: base(message)
+		{
+			StatusCode = statusCode;
+			ResponseBody = responseBody;
+		}
+
+		public CliApiException(string message, Exception innerException)
+			: base(message, innerException)
+		{
+		}
+	}
+}

--- a/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
+++ b/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
@@ -24,6 +24,7 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 		private readonly DpopKey _dpopKey;
 		private readonly object _lock = new();
 		private CliAuthSession? _session;
+		private bool _forceReauth;
 
 		public DpopKey Key => _dpopKey;
 
@@ -33,6 +34,7 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 			lock (_lock)
 			{
 				_session = null;
+				_forceReauth = true;
 			}
 		}
 
@@ -51,9 +53,11 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 
 		public async Task<CliAuthSession> GetSessionAsync(CancellationToken cancellationToken)
 		{
+			bool forceReauth;
 			lock (_lock)
 			{
-				if (_session != null && _session.ExpiresAtUtc > DateTime.UtcNow.AddSeconds(60))
+				forceReauth = _forceReauth;
+				if (!forceReauth && _session != null && _session.ExpiresAtUtc > DateTime.UtcNow.AddSeconds(60))
 				{
 					return _session;
 				}
@@ -62,6 +66,17 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 			var stored = _store.Load();
 			if (stored is not null)
 			{
+				if (!forceReauth && stored.ExpiresAtUtc > DateTime.UtcNow.AddSeconds(60))
+				{
+					// Parity with scalable-cli refresh_session_if_needed_at: a fresh access token is reused without a network call.
+					lock (_lock)
+					{
+						_session = stored;
+					}
+
+					return stored;
+				}
+
 				try
 				{
 					await RefreshAsync(stored, cancellationToken);
@@ -197,6 +212,7 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 			lock (_lock)
 			{
 				_session = new CliAuthSession(accessToken, refreshToken, expiresAtUtc, personId, sessionId);
+				_forceReauth = false;
 			}
 
 			try
@@ -330,7 +346,17 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 			catch (Exception)
 			{
 				// Any corrupt or unreadable key file: start fresh. The DPoP key is self-describing in every proof, so rotation is safe.
-				return DpopKey.Create();
+				var key = DpopKey.Create();
+				try
+				{
+					File.WriteAllText(path, key.ToJson());
+				}
+				catch (Exception)
+				{
+					// Best effort: the in-memory key still works for this run even if the file stays corrupt.
+				}
+
+				return key;
 			}
 		}
 
@@ -366,6 +392,12 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 		public CliApiException(string message)
 			: base(message)
 		{
+		}
+
+		public CliApiException(string message, string responseBody)
+			: base(message)
+		{
+			ResponseBody = responseBody;
 		}
 
 		public CliApiException(string message, int statusCode, string responseBody)

--- a/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
+++ b/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
@@ -27,6 +27,15 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 
 		public DpopKey Key => _dpopKey;
 
+		/// <summary>Forces the next GetSessionAsync call to re-authenticate from stored tokens (or device login).</summary>
+		public void InvalidateSession()
+		{
+			lock (_lock)
+			{
+				_session = null;
+			}
+		}
+
 		public CliTokenProvider(HttpClient httpClient, ILogger logger)
 			: this(httpClient, logger, new CliTokenStore(), LoadOrCreateDpopKey())
 		{
@@ -314,7 +323,7 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 				File.WriteAllText(path, key.ToJson());
 				return key;
 			}
-			catch (Exception ex) when (ex is IOException or InvalidOperationException or JsonException)
+			catch (Exception ex) when (ex is IOException or InvalidOperationException or JsonException or KeyNotFoundException)
 			{
 				// Corrupt or unreadable key file: start fresh. The DPoP key is self-describing in every proof, so rotation is safe.
 				return DpopKey.Create();

--- a/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
+++ b/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
@@ -28,6 +28,9 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 
 		public DpopKey Key => _dpopKey;
 
+		/// <summary>Invoked once after a successful device-code login, before the session is considered usable.</summary>
+		public Func<CliAuthSession, CancellationToken, Task>? OnDeviceLogin { get; set; }
+
 		/// <summary>Forces the next GetSessionAsync call to re-authenticate from stored tokens (or device login).</summary>
 		public void InvalidateSession()
 		{
@@ -160,6 +163,30 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 				{
 					var body = await PostFormAsync($"{Issuer}/oauth/token", form, null, cancellationToken);
 					await ApplyTokenResponseAsync(body, string.Empty, cancellationToken);
+					if (OnDeviceLogin is not null)
+					{
+						try
+						{
+							await OnDeviceLogin(_session!, cancellationToken);
+						}
+						catch (OperationCanceledException)
+						{
+							throw;
+						}
+						catch (Exception ex)
+						{
+							// Parity with scalable-cli: a failed trusted-device 2FA challenge aborts the login and discards the session.
+							_store.Clear();
+							lock (_lock)
+							{
+								_session = null;
+								_forceReauth = true;
+							}
+
+							throw new CliApiException($"Trusted device 2FA on login failed: {ex.Message}", ex);
+						}
+					}
+
 					return;
 				}
 				// Parity with scalable-cli: device-flow states are matched on the OAuth error code, not the HTTP status.

--- a/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
+++ b/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
@@ -293,7 +293,7 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 						continue;
 					}
 
-					throw new CliApiException($"CLI API HTTP error {(int)response.StatusCode}: {responseBody}", (int)response.StatusCode, responseBody);
+					throw new CliApiException($"CLI API HTTP error {(int)response.StatusCode} from {url}: {TruncateForDiagnostics(responseBody)}", (int)response.StatusCode, responseBody);
 				}
 				finally
 				{
@@ -317,6 +317,8 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 			var lower = body.ToLowerInvariant();
 			return statusCode == 401 || lower.Contains("use_dpop_nonce") || lower.Contains("invalid_dpop_proof");
 		}
+
+		private static string TruncateForDiagnostics(string body) => body.Length <= 200 ? body : $"{body[..200]}…";
 
 		private static string? ParseOAuthError(string body)
 		{

--- a/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
+++ b/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
@@ -16,7 +16,7 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 		private const string Audience = "https://de.scalable.capital/api-gateway";
 		private const string Scope = "offline_access openid email";
 
-		private static readonly Uri Issuer = new("https://secure.scalable.capital");
+		private const string Issuer = "https://secure.scalable.capital";
 
 		private readonly HttpClient _httpClient;
 		private readonly ILogger _logger;

--- a/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
+++ b/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
@@ -162,11 +162,13 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 						continue;
 					}
 
-					throw new CliApiException(state switch
+					var rawBody = ex.ResponseBody?.Trim();
+					var detail = state ?? (string.IsNullOrWhiteSpace(rawBody) ? "unknown error" : Shorten(rawBody));
+					throw new CliApiException(detail switch
 					{
 						"access_denied" => "Device login denied by user.",
 						"expired_token" => "Device login code expired.",
-						_ => $"Device code polling failed: {state}"
+						_ => $"Device code polling failed: {detail}"
 					});
 				}
 			}
@@ -272,6 +274,8 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 			}
 		}
 
+		private static string Shorten(string value) => value.Length <= 200 ? value : $"{value[..200]}...";
+
 		private static Dictionary<string, JsonElement> DecodeJwtClaims(string jwt)
 		{
 			var parts = jwt.Split('.');
@@ -323,9 +327,9 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 				File.WriteAllText(path, key.ToJson());
 				return key;
 			}
-			catch (Exception ex) when (ex is IOException or InvalidOperationException or JsonException or KeyNotFoundException)
+			catch (Exception)
 			{
-				// Corrupt or unreadable key file: start fresh. The DPoP key is self-describing in every proof, so rotation is safe.
+				// Any corrupt or unreadable key file: start fresh. The DPoP key is self-describing in every proof, so rotation is safe.
 				return DpopKey.Create();
 			}
 		}

--- a/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
+++ b/Tools/ScraperUtilities/CliApi/CliTokenProvider.cs
@@ -162,7 +162,8 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 					await ApplyTokenResponseAsync(body, string.Empty, cancellationToken);
 					return;
 				}
-				catch (CliApiException ex) when (ex.StatusCode == 400 && !string.IsNullOrWhiteSpace(ex.ResponseBody))
+				// Parity with scalable-cli: device-flow states are matched on the OAuth error code, not the HTTP status.
+				catch (CliApiException ex) when (!string.IsNullOrWhiteSpace(ex.ResponseBody))
 				{
 					var state = ParseOAuthError(ex.ResponseBody!);
 					if (state == "authorization_pending")
@@ -183,7 +184,7 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 					{
 						"access_denied" => "Device login denied by user.",
 						"expired_token" => "Device login code expired.",
-						_ => $"Device code polling failed: {detail}"
+						_ => $"Device code polling failed (HTTP {(int)ex.StatusCode!}): {detail}"
 					});
 				}
 			}
@@ -200,8 +201,21 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 				throw new CliApiException("CLI API token endpoint returned no refresh token.");
 			}
 
-			var expiresAtUtc = DateTime.UtcNow.AddSeconds(root.TryGetProperty("expires_in", out var exp) && exp.ValueKind == JsonValueKind.Number ? exp.GetInt32() : 1200);
 			var claims = DecodeJwtClaims(accessToken);
+			DateTime expiresAtUtc;
+			if (root.TryGetProperty("expires_in", out var expiresIn) && expiresIn.ValueKind == JsonValueKind.Number)
+			{
+				expiresAtUtc = DateTime.UtcNow.AddSeconds(expiresIn.GetInt32());
+			}
+			else if (claims.TryGetValue("exp", out var expClaim) && expClaim.ValueKind == JsonValueKind.Number)
+			{
+				// Parity with scalable-cli: fall back to the JWT exp claim when the token response omits expires_in.
+				expiresAtUtc = DateTimeOffset.FromUnixTimeSeconds(expClaim.GetInt64()).UtcDateTime;
+			}
+			else
+			{
+				expiresAtUtc = DateTime.UtcNow.AddSeconds(1200);
+			}
 			var personId = FirstClaim(claims, "person_id", "https://de.scalable.capital/person_id", "https://de.scalable.capital/personId") ?? fallbackPersonId;
 			if (string.IsNullOrWhiteSpace(personId))
 			{

--- a/Tools/ScraperUtilities/CliApi/CliTokenStore.cs
+++ b/Tools/ScraperUtilities/CliApi/CliTokenStore.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+
+namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
+{
+	/// <summary>
+	/// Persists Scalable Capital CLI API login state in %LOCALAPPDATA% so the device-code login only happens once.
+	/// </summary>
+	public class CliTokenStore
+	{
+		private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+		private readonly string _filePath;
+
+		public CliTokenStore()
+		{
+			var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "GhostfolioSidekick");
+			Directory.CreateDirectory(dir);
+			_filePath = Path.Combine(dir, "cli-tokens.json");
+		}
+
+		internal string FilePath => _filePath;
+
+		public CliAuthSession? Load()
+		{
+			if (!File.Exists(_filePath))
+			{
+				return null;
+			}
+
+			try
+			{
+				var json = File.ReadAllText(_filePath);
+				using var document = JsonDocument.Parse(json);
+				var root = document.RootElement;
+				var accessToken = root.GetProperty("accessToken").GetString();
+				if (string.IsNullOrWhiteSpace(accessToken))
+				{
+					return null;
+				}
+
+				long expiresAtEpoch = 0;
+				if (root.TryGetProperty("expiresAtEpoch", out var exp) && exp.ValueKind == System.Text.Json.JsonValueKind.Number)
+				{
+					expiresAtEpoch = exp.GetInt64();
+				}
+
+				return new CliAuthSession(
+					accessToken,
+					root.TryGetProperty("refreshToken", out var rt) ? rt.GetString() : null,
+					DateTimeOffset.FromUnixTimeSeconds(expiresAtEpoch).UtcDateTime,
+					root.TryGetProperty("personId", out var pid) ? pid.GetString() ?? string.Empty : string.Empty,
+					root.TryGetProperty("sessionId", out var sid) ? sid.GetString() : null);
+			}
+			catch (JsonException)
+			{
+				return null;
+			}
+			catch (IOException)
+			{
+				// Unreadable token file: treat as no stored login and fall back to interactive login.
+				return null;
+			}
+		}
+
+		public void Save(CliAuthSession session)
+		{
+			var payload = new
+			{
+				accessToken = session.AccessToken,
+				refreshToken = session.RefreshToken,
+				expiresAtEpoch = new DateTimeOffset(session.ExpiresAtUtc, TimeSpan.Zero).ToUnixTimeSeconds(),
+				personId = session.PersonId,
+				sessionId = session.SessionId
+			};
+
+			File.WriteAllText(_filePath, JsonSerializer.Serialize(payload, JsonOptions));
+		}
+
+		public void Clear()
+		{
+			if (File.Exists(_filePath))
+			{
+				File.Delete(_filePath);
+			}
+		}
+	}
+}

--- a/Tools/ScraperUtilities/CliApi/CliTokenStore.cs
+++ b/Tools/ScraperUtilities/CliApi/CliTokenStore.cs
@@ -51,13 +51,9 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 					root.TryGetProperty("personId", out var pid) ? pid.GetString() ?? string.Empty : string.Empty,
 					root.TryGetProperty("sessionId", out var sid) ? sid.GetString() : null);
 			}
-			catch (JsonException)
+			catch (Exception ex) when (ex is JsonException or KeyNotFoundException or IOException)
 			{
-				return null;
-			}
-			catch (IOException)
-			{
-				// Unreadable token file: treat as no stored login and fall back to interactive login.
+				// Corrupt or unreadable token file: treat as no stored login and fall back to interactive login.
 				return null;
 			}
 		}

--- a/Tools/ScraperUtilities/CliApi/CliTokenStore.cs
+++ b/Tools/ScraperUtilities/CliApi/CliTokenStore.cs
@@ -51,9 +51,9 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
 					root.TryGetProperty("personId", out var pid) ? pid.GetString() ?? string.Empty : string.Empty,
 					root.TryGetProperty("sessionId", out var sid) ? sid.GetString() : null);
 			}
-			catch (Exception ex) when (ex is JsonException or KeyNotFoundException or IOException)
+			catch (Exception)
 			{
-				// Corrupt or unreadable token file: treat as no stored login and fall back to interactive login.
+				// Any corrupt or unreadable token file: treat as no stored login and fall back to interactive login.
 				return null;
 			}
 		}

--- a/Tools/ScraperUtilities/CliApi/DpopKey.cs
+++ b/Tools/ScraperUtilities/CliApi/DpopKey.cs
@@ -1,0 +1,123 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
+{
+	/// <summary>
+	/// P-256 ECDSA key used to sign DPoP proof JWTs for the Scalable Capital CLI API.
+	/// Persisted as a minimal JWK ({"kty":"EC","crv":"P-256","d":...}) so login only happens once.
+	/// </summary>
+	public class DpopKey : IDisposable
+	{
+		private readonly ECDsa _key;
+
+		private DpopKey(ECDsa key)
+		{
+			_key = key;
+		}
+
+		public static DpopKey Create() => new(ECDsa.Create(ECCurve.NamedCurves.nistP256));
+
+		public static DpopKey Load(string json)
+		{
+			using var document = JsonDocument.Parse(json);
+			var root = document.RootElement;
+			if (root.GetProperty("kty").GetString() != "EC" || root.GetProperty("crv").GetString() != "P-256")
+			{
+				throw new InvalidOperationException("DPoP key file is not an EC/P-256 JWK.");
+			}
+
+			var dValue = root.GetProperty("d").GetString();
+			if (string.IsNullOrWhiteSpace(dValue))
+			{
+				throw new InvalidOperationException("DPoP key file is missing the private key scalar.");
+			}
+
+			var scalar = Base64UrlDecode(dValue);
+			if (scalar.Length != 32)
+			{
+				throw new InvalidOperationException($"Invalid DPoP private key scalar length {scalar.Length}; expected 32 bytes.");
+			}
+
+			var parameters = new ECParameters { Curve = ECCurve.NamedCurves.nistP256, D = scalar };
+			return new DpopKey(ECDsa.Create(parameters));
+		}
+
+		public string ToJson()
+		{
+			var d = _key.ExportParameters(true).D ?? throw new InvalidOperationException("ECDsa key has no private scalar.");
+			return $"{{\"kty\":\"EC\",\"crv\":\"P-256\",\"d\":\"{Base64UrlEncode(d)}\"}}";
+		}
+
+		public string BuildProof(string method, Uri targetUri, string? nonce, string? accessToken)
+		{
+			var q = _key.ExportParameters(false).Q;
+			var header = new JsonObject
+			{
+				["typ"] = "dpop+jwt",
+				["alg"] = "ES256",
+				["jwk"] = new JsonObject
+				{
+					["kty"] = "EC",
+					["crv"] = "P-256",
+					["x"] = Base64UrlEncode(FixedSize32(q.X)),
+					["y"] = Base64UrlEncode(FixedSize32(q.Y))
+				}
+			};
+
+			var claims = new JsonObject
+			{
+				["htm"] = method,
+				["htu"] = targetUri.GetLeftPart(UriPartial.Path),
+				["iat"] = (int)DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+				["jti"] = Base64UrlEncode(RandomNumberGenerator.GetBytes(16))
+			};
+
+			if (!string.IsNullOrWhiteSpace(nonce))
+			{
+				claims["nonce"] = nonce;
+			}
+
+			if (!string.IsNullOrWhiteSpace(accessToken))
+			{
+				using var sha256 = SHA256.Create();
+				var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(accessToken));
+				claims["ath"] = Base64UrlEncode(hash);
+			}
+
+			var signingInput = $"{Base64UrlEncode(JsonSerializer.SerializeToUtf8Bytes(header))}.{Base64UrlEncode(JsonSerializer.SerializeToUtf8Bytes(claims))}";
+			using var ecdsa = ECDsa.Create(_key.ExportParameters(true));
+			var signature = ecdsa.SignData(Encoding.UTF8.GetBytes(signingInput), HashAlgorithmName.SHA256);
+			return $"{signingInput}.{Base64UrlEncode(signature)}";
+		}
+
+		public void Dispose() => _key.Dispose();
+
+		private static byte[] FixedSize32(byte[]? value)
+		{
+			if (value == null)
+			{
+				throw new InvalidOperationException("ECDsa public point coordinate is missing.");
+			}
+
+			if (value.Length == 32)
+			{
+				return value;
+			}
+
+			var result = new byte[32];
+			Array.Copy(value, 0, result, 32 - value.Length, value.Length);
+			return result;
+		}
+
+		public static string Base64UrlEncode(byte[] bytes) => Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+		private static byte[] Base64UrlDecode(string value)
+		{
+			var base64 = value.Replace('-', '+').Replace('_', '/');
+			return Convert.FromBase64String(base64.PadRight(base64.Length + (4 - base64.Length % 4) % 4, '='));
+		}
+	}
+}

--- a/Tools/ScraperUtilities/CliApi/TrustedDevice2Fa.cs
+++ b/Tools/ScraperUtilities/CliApi/TrustedDevice2Fa.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace GhostfolioSidekick.Tools.ScraperUtilities.CliApi
+{
+	/// <summary>
+	/// Trusted-device 2FA on login, parity with scalable-cli's handle_post_login_mfa.
+	/// Runs after a successful device-code login: if the account has 2FA-on-login enabled and no approved session exists yet,
+	/// start a challenge and poll until it is completed in the browser.
+	/// </summary>
+	public static class TrustedDevice2Fa
+	{
+		private const int PollIntervalSeconds = 2;
+		private const int TimeoutSeconds = 120;
+
+		private static readonly string Is2faOnLoginEnabledQuery = @"
+query Is2faOnLoginEnabled($input: Is2faOnLoginEnabledInput!) {
+  is2faOnLoginEnabled(input: $input) {
+    enabled
+    hasApprovedSession
+  }
+}";
+
+		private static readonly string Start2faOnLoginMutation = @"
+mutation Start2faOnLogin($input: Start2faOnLoginInput!) {
+  start2faOnLogin(input: $input) {
+    mfaSessionId
+  }
+}";
+
+		private static readonly string Validate2faOnLoginMutation = @"
+mutation Validate2faOnLogin($input: Validate2faOnLoginInput!) {
+  validate2faOnLogin(input: $input) {
+    status
+  }
+}";
+
+		public static async Task EnsureApprovedSessionAsync(CliGraphqlClient client, string personId, ILogger logger, CancellationToken cancellationToken)
+		{
+			var state = await client.QueryAsync(Is2faOnLoginEnabledQuery, new { input = new { userId = personId } }, "Is2faOnLoginEnabled", cancellationToken);
+			var enabledNode = state?["is2faOnLoginEnabled"]?["enabled"];
+			if (enabledNode?.GetValueKind() != JsonValueKind.True)
+			{
+				return;
+			}
+
+			var approvedNode = state?["is2faOnLoginEnabled"]?["hasApprovedSession"];
+			if (approvedNode?.GetValueKind() == JsonValueKind.True)
+			{
+				return;
+			}
+
+			var start = await client.QueryAsync(Start2faOnLoginMutation, new { input = new { userId = personId, deviceName = "CLI", deviceType = "CLI" } }, "Start2faOnLogin", cancellationToken);
+			var mfaSessionId = start?["start2faOnLogin"]?["mfaSessionId"]?.GetValue<string>();
+			if (string.IsNullOrWhiteSpace(mfaSessionId))
+			{
+				throw new CliApiException("2FA on login is enabled but mfaSessionId was not returned");
+			}
+
+			logger.LogInformation("2FA on login enabled; complete the challenge in your browser.");
+			var deadline = DateTime.UtcNow.AddSeconds(TimeoutSeconds);
+			while (true)
+			{
+				if (DateTime.UtcNow >= deadline)
+				{
+					throw new CliApiException("2FA login challenge timed out");
+				}
+
+				cancellationToken.ThrowIfCancellationRequested();
+				var validate = await client.QueryAsync(Validate2faOnLoginMutation, new { input = new { userId = personId, mfaSessionId } }, "Validate2faOnLogin", cancellationToken);
+				var status = validate?["validate2faOnLogin"]?["status"]?.GetValue<string>();
+				switch (status)
+				{
+					case "SUCCESS":
+						logger.LogInformation("2FA on login approved.");
+						return;
+					case "PENDING":
+						await Task.Delay(TimeSpan.FromSeconds(PollIntervalSeconds), cancellationToken);
+						continue;
+					case "DENY":
+						throw new CliApiException("2FA login challenge denied");
+					case "TIMEOUT_RETRY":
+						throw new CliApiException("2FA login timed out; please retry");
+					case null:
+						throw new CliApiException("Missing 2FA status in response");
+					default:
+						throw new CliApiException($"Unexpected 2FA status: {status}");
+				}
+			}
+		}
+	}
+}

--- a/Tools/ScraperUtilities/ScraperService.cs
+++ b/Tools/ScraperUtilities/ScraperService.cs
@@ -21,6 +21,7 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities
 				Console.WriteLine("Select your scraper");
 				Console.WriteLine("1. Scalable Capital (browser)");
 				Console.WriteLine("2. Scalable Capital (MCP server)");
+				Console.WriteLine("3. Scalable Capital (CLI API)");
 				Console.WriteLine("0. Exit");
 				var input = Console.ReadLine();
 				if (input == null)
@@ -30,6 +31,7 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities
 
 				SupportedBrokers? broker;
 				bool useMcp = false;
+				bool useCliApi = false;
 				switch (input)
 				{
 					case "1":
@@ -39,6 +41,10 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities
 						broker = SupportedBrokers.ScalableCapital;
 						useMcp = true;
 						break;
+					case "3":
+						broker = SupportedBrokers.ScalableCapital;
+						useCliApi = true;
+						break;
 					case "0":
 						Environment.Exit(0);
 						return;
@@ -47,7 +53,7 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities
 						continue;
 				}
 
-				await RunAsync(broker.Value, outputDirectory, useMcp);
+				await RunAsync(broker.Value, outputDirectory, useMcp, useCliApi);
 			}
 		}
 
@@ -56,14 +62,18 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities
 			return Task.CompletedTask;
 		}
 
-		public async Task RunAsync(SupportedBrokers broker, string outputDirectory, bool useMcp = false)
+		public async Task RunAsync(SupportedBrokers broker, string outputDirectory, bool useMcp = false, bool useCliApi = false)
 		{
 			logger.LogInformation("Starting the scraping process...");
 			logger.LogInformation("Broker: {Broker}", broker);
 			logger.LogInformation("Output directory: {OutputDirectory}", outputDirectory);
 
 			Dictionary<int, IEnumerable<ActivityWithSymbol>> transactions;
-			if (useMcp && broker == SupportedBrokers.ScalableCapital)
+			if (useCliApi && broker == SupportedBrokers.ScalableCapital)
+			{
+				transactions = await RunCliApiScrapeAsync();
+			}
+			else if (useMcp && broker == SupportedBrokers.ScalableCapital)
 			{
 				transactions = await RunMcpScrapeAsync();
 			}
@@ -105,6 +115,15 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities
 			using var tokenProvider = new Mcp.McpTokenProvider(httpClient, logger);
 			using var mcpClient = new Mcp.McpClient(httpClient, tokenProvider, logger);
 			var scraper = new Mcp.McpScraper(mcpClient, logger);
+			return await scraper.ScrapeTransactionsAsync(CancellationToken.None);
+		}
+
+		private async Task<Dictionary<int, IEnumerable<ActivityWithSymbol>>> RunCliApiScrapeAsync()
+		{
+			using var httpClient = new HttpClient();
+			using var tokenProvider = new CliApi.CliTokenProvider(httpClient, logger);
+			using var client = new CliApi.CliGraphqlClient(httpClient, tokenProvider.Key, tokenProvider);
+			var scraper = new CliApi.CliScraper(client, tokenProvider, logger);
 			return await scraper.ScrapeTransactionsAsync(CancellationToken.None);
 		}
 	}

--- a/Tools/ScraperUtilities/ScraperService.cs
+++ b/Tools/ScraperUtilities/ScraperService.cs
@@ -123,6 +123,7 @@ namespace GhostfolioSidekick.Tools.ScraperUtilities
 			using var httpClient = new HttpClient();
 			using var tokenProvider = new CliApi.CliTokenProvider(httpClient, logger);
 			using var client = new CliApi.CliGraphqlClient(httpClient, tokenProvider.Key, tokenProvider);
+			tokenProvider.OnDeviceLogin = (session, ct) => CliApi.TrustedDevice2Fa.EnsureApprovedSessionAsync(client, session.PersonId, logger, ct);
 			var scraper = new CliApi.CliScraper(client, tokenProvider, logger);
 			return await scraper.ScrapeTransactionsAsync(CancellationToken.None);
 		}


### PR DESCRIPTION
The MCP server omits overnight transaction details and the official scalable-cli has no Windows build, so port its device-code login, DPoP proofs and GraphQL queries to C# as a separate scraper path (menu 3). Produces the same per-account CSV output contract; MCP/browser paths untouched.